### PR TITLE
allow node_modules/truex-shared modules to be processed by babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],


### PR DESCRIPTION
...when using browserify

### JIRA
https://truextech.atlassian.net/browse/CTV-1687

### Description
Fix truex-shared-js' package.json to support babel usage found in node_modules by browserify
This will support the itegration_core build tasks via grunt using browserify.

### Testing
unit tests pass

### Commit Message Subject(s)
allow node_modules/truex-shared modules to be processed by babel

### Additional Context
n/a

### Related PRs
https://github.com/socialvibe/integration_core/pull/49

### Checks
- [ x] Includes unit test coverage _(if applicable)_
- [x ] Includes functional test coverage _(at feature-level, if applicable)_
- [ ] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

