### PR TITLE
Bugfix/ctv 1198 reference app support fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -165,7 +165,7 @@ describe("TXMPlatform", () => {
         });
 
         let platform = new TXMPlatform(
-            "Mozilla/5.0 (PlayStation 4 WebMAF) AppleWebKit/601.2 (KHTML, like Gecko) WebMAF/1.2.30.4-gd34FFEE something extra"
+            "Mozilla/5.0 (PlayStation 4 WebMAF) AppleWebKit/601.2 (KHTML, like Gecko) WebMAF/v1.2.30.4-gd34FFEE something extra"
         );
 
         test("recognize the PS4 platform, new version", () => {
@@ -177,7 +177,7 @@ describe("TXMPlatform", () => {
             expect(platform.isXboxOne).toBe(false);
             expect(platform.name).toBe("PS4");
             expect(platform.model).toBe("PS4");
-            expect(platform.version).toBe("1.2.30.4");
+            expect(platform.version).toBe("WebMAF/v1.2.30.4");
             expect(platform.isCTV).toBe(false);
             expect(platform.isConsole).toBe(true);
         });

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -147,11 +147,10 @@ describe("TXMPlatform", () => {
     });
 
     describe("PS4 Tests", () => {
-        let platform = new TXMPlatform(
-            "Mozilla/5.0 (PlayStation 4 5.05) AppleWebKit/601.2 (KHTML, like Gecko)"
-        );
-
-        test("recognize the PS4 platform", () => {
+        test("recognize the PS4 platform, old version", () => {
+            let platform = new TXMPlatform(
+                "Mozilla/5.0 (PlayStation 4 5.05) AppleWebKit/601.2 (KHTML, like Gecko)"
+            );
             expect(platform.isUnknown).toBe(false);
             expect(platform.isVizio).toBe(false);
             expect(platform.isLG).toBe(false);
@@ -161,6 +160,24 @@ describe("TXMPlatform", () => {
             expect(platform.name).toBe("PS4");
             expect(platform.model).toBe("PS4");
             expect(platform.version).toBe("5.05");
+            expect(platform.isCTV).toBe(false);
+            expect(platform.isConsole).toBe(true);
+        });
+
+        let platform = new TXMPlatform(
+            "Mozilla/5.0 (PlayStation 4 WebMAF) AppleWebKit/601.2 (KHTML, like Gecko) WebMAF/1.2.30.4-gd34FFEE something extra"
+        );
+
+        test("recognize the PS4 platform, new version", () => {
+            expect(platform.isUnknown).toBe(false);
+            expect(platform.isVizio).toBe(false);
+            expect(platform.isLG).toBe(false);
+            expect(platform.isTizen).toBe(false);
+            expect(platform.isPS4).toBe(true);
+            expect(platform.isXboxOne).toBe(false);
+            expect(platform.name).toBe("PS4");
+            expect(platform.model).toBe("PS4");
+            expect(platform.version).toBe("1.2.30.4");
             expect(platform.isCTV).toBe(false);
             expect(platform.isConsole).toBe(true);
         });

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -78,7 +78,7 @@ export class TXMPlatform {
 
         this.supportsGyro = false; // on all platforms except perhaps for the Switch?
 
-        // Indicates if the platform player start playback directly at a specified time position.
+        // Indicates if the platform player can start playback directly at a specified time position.
         // If false then one needs to start playback first before seeking works.
         this.supportsInitialVideoSeek = true;
 

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -344,7 +344,7 @@ export class TXMPlatform {
             self.name = "PS4";
             self.model = self.name;
 
-            let versionMatch = userAgent.match(/WebMAF\/([0-9]+\.?)+/);
+            let versionMatch = userAgent.match(/WebMAF\/(([0-9]+\.)+[0-9]+)/);
             if (!versionMatch) {
                 // Not found, fallback to older user agent pattern.
                 versionMatch = userAgent.match(/PlayStation 4 ([^\s)]+)\)/);

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -78,6 +78,9 @@ export class TXMPlatform {
 
         this.supportsGyro = false; // on all platforms except perhaps for the Switch?
 
+        // Indicates if the platform player start playback directly at a specified time position.
+        // If false then one needs to start playback first before seeking works.
+        this.supportsInitialVideoSeek = true;
 
         // Most platforms allow http: image GETs when running under https:, even the latest Chrome.
         // AndroidTV/FireTV does not however.
@@ -340,10 +343,17 @@ export class TXMPlatform {
             self.isPS4 = true;
             self.name = "PS4";
             self.model = self.name;
-            let versionMatch = userAgent.match(/PlayStation 4 ([^\s)]+)\)/);
+
+            let versionMatch = userAgent.match(/WebMAF\/([0-9]+\.?)+/);
+            if (!versionMatch) {
+                // Not found, fallback to older user agent pattern.
+                versionMatch = userAgent.match(/PlayStation 4 ([^\s)]+)\)/);
+            }
             if (versionMatch) self.version = versionMatch[1];
 
             self.useWindowScroll = false;
+
+            self.supportsInitialVideoSeek = false;
 
             addDefaultKeyMap();
             actionKeyCodes[inputActions.buttonSquare] = 32;

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -344,7 +344,7 @@ export class TXMPlatform {
             self.name = "PS4";
             self.model = self.name;
 
-            let versionMatch = userAgent.match(/WebMAF\/(([0-9]+\.)+[0-9]+)/);
+            let versionMatch = userAgent.match(/(WebMAF\/v([0-9]+\.)+[0-9]+)/);
             if (!versionMatch) {
                 // Not found, fallback to older user agent pattern.
                 versionMatch = userAgent.match(/PlayStation 4 ([^\s)]+)\)/);


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-1198

### Description
Fixes to support the reference app:
* block back action cleanup
* PS4 platform version value fixes
* add supportsInitialVideoSeek flag to detect PS4 initial seek failures

### Testing
Unit tests, run Skyline on PS4, FireTV, Chrome

### Commit Message Subject(s)
CTV-1898: reference app support fixes

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
