### PR TITLE
Bugfix/ctv 1198 android tv fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.63",
+  "version": "1.0.64",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -49,7 +49,7 @@ describe("TXMPlatform", () => {
             expect(platform.name).toBe("FireTV");
             expect(platform.model).toBe("Fire TV Stick (Gen 2)");
             expect(platform.modelId).toBe("AFTT");
-            expect(platform.version).toBe("3.4.0");
+            expect(platform.version).toBe("5.1.1");
             expect(platform.isCTV).toBe(true);
             expect(platform.isConsole).toBe(false);
         });

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -474,16 +474,6 @@ export class TXMPlatform {
             }
 
             actionKeyCodes[inputActions.menu] = 18;
-
-            /*
-            In contradiction to the Amazon FireTV Web FAQ, the back key event can actually be fielded by the app.
-            see: https://developer.amazon.com/docs/fire-tv/web-app-faq.html
-            see: https://forums.developer.amazon.com/questions/11752/particulars-of-html5-history-popstate-event-on-ama.html
-            Also verified experimentally ourselves.
-
-            However, fielding that keystroke is still not reliable as the history back and popstate event processing
-            still occurs regardless. */
-            self.useHistoryBackActions = true;
         }
 
         function configureForAndroidTV() {
@@ -502,6 +492,17 @@ export class TXMPlatform {
             // Both AndroidTV and FireTV do not allow http: image GETs when
             // running under https:
             self.supportsHttpImagesWithHttps = false;
+
+            // Both Android TV and Fire TV use history back actions instead of the explicit back key event.
+            //
+            // In contradiction to the Amazon FireTV Web FAQ, the back key event can actually be fielded by the app.
+            // see: https://developer.amazon.com/docs/fire-tv/web-app-faq.html
+            // see: https://forums.developer.amazon.com/questions/11752/particulars-of-html5-history-popstate-event-on-ama.html
+            // Also verified experimentally ourselves.
+            //
+            // However, fielding that keystroke is still not reliable as the history back and popstate event processing
+            // still occurs regardless.
+            self.useHistoryBackActions = true;
 
             const androidApp = window.androidApp || window.fireTVApp;
             if (androidApp) {

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -468,11 +468,6 @@ export class TXMPlatform {
             self.model = model;
             self.modelId = modelId;
 
-            const versionMatch = userAgent.match(/-fireos\/([^\s)]+)/);
-            if (versionMatch) {
-                self.version = versionMatch[1];
-            }
-
             actionKeyCodes[inputActions.menu] = 18;
         }
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-1198

### Description
Fixes for running correctly on both Android TV and Fire TV
* useHistoryBackActions is needed for Android TV as well
* remove -fireos/ version check, that only happens when running via Amazon Web App Tester

### Testing
unit tests, run from ref app and skyline

### Commit Message Subject(s)
CTV-1198: Android TV fixes

### Additional Context
n/a

### Related PRs
OPTIONAL_ADD_PR_LINKS

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

