### PR TITLE
Bugfix/ctv 2012 bluescript continued fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.66",
+  "version": "1.0.67",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.64",
+  "version": "1.0.65",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.65",
+  "version": "1.0.66",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -552,5 +552,39 @@ describe("TXMFocusManager", () => {
                 expect(fm.currentFocus).toBe(focuses[1]);
             });
         });
+
+        describe("derived 2D focus navigation", () => {
+            const fm = new TXMFocusManager();
+
+            function newStub({id, top, left, bottom, right}) {
+                const element = {id, top, left, bottom, right, width: right - left, height: bottom - top};
+                element.getBoundingClientRect = () => element;
+                element.classList = {
+                    add: () => {},
+                    remove: () => {}
+                };
+                return new Focusable(element);
+            }
+
+            const f_0_0 = newStub({id: "f_0_0", top: 10, left: 10, bottom: 50, right: 50});
+            const f_0_1 = newStub({id: "f_0_1", top: 20, left: 60, bottom: 60, right: 100}); // overlaps, still in same row
+            const f_1_0 = newStub({id: "f_1_0", top: 80, left: 20, bottom: 120, right: 60});
+            const f_1_1 = newStub({id: "f_1_1", top: 80, left: 80, bottom: 120, right: 120});
+            const f_1_2 = newStub({id: "f_1_2", top: 70, left: 140, bottom: 110, right: 180});  // overlaps, still in same row
+            const f_2_0 = newStub({id: "f_2_0", top: 400, left: 200, bottom: 440, right: 240});
+
+            const focusablesInOrder = fm.derive2DNavigationArray([f_2_0, f_0_0, f_1_2, f_1_1, f_0_1, f_1_0]);
+            expect(focusablesInOrder.length).toBe(3);
+            expect(focusablesInOrder[0]).toEqual([f_0_0, f_0_1]);
+            expect(focusablesInOrder[1]).toEqual([f_1_0, f_1_1, f_1_2]);
+            expect(focusablesInOrder[2]).toEqual([f_2_0]);
+
+            fm.setContentFocusables(focusablesInOrder);
+            expect(fm.currentFocus).toBe(focusablesInOrder[0][0]);
+            fm.onInputAction(inputActions.moveDown);
+            expect(fm.currentFocus).toBe(focusablesInOrder[1][0]);
+            fm.onInputAction(inputActions.moveDown);
+            expect(fm.currentFocus).toBe(focusablesInOrder[2][0]);
+        });
     });
 });

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -573,6 +573,8 @@ export class TXMFocusManager {
         return resultBounds.map(row => row.map(item => item.focusable));
 
         function deriveFromBounds(bounds) {
+            if (!bounds || bounds.length <= 0) return [];
+
             const boundsAbove = [];
             const boundsBelow = [];
             const boundsInRow = [];

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -567,38 +567,39 @@ export class TXMFocusManager {
             return item1.bounds.left - item2.bounds.left;
         });
 
-        const resultBounds = deriveFromBounds(focusablesAndBounds);
+        const result = deriveRows(focusablesAndBounds);
 
-        // Now give the 2D array of just focusables.
-        return resultBounds.map(row => row.map(item => item.focusable));
+        // Now give the 2D array of just the focusables.
+        return result.map(row => row.map(item => item.focusable));
 
-        function deriveFromBounds(bounds) {
-            if (!bounds || bounds.length <= 0) return [];
+        function deriveRows(items) {
+            if (!items || items.length <= 0) return [];
 
-            const boundsAbove = [];
-            const boundsBelow = [];
-            const boundsInRow = [];
+            const itemsAbove = [];
+            const itemsBelow = [];
+            const itemsInRow = [];
 
-            let lastItem;
-            bounds.forEach(item => {
-                if (lastItem && item.bottom <= lastItem.top) {
-                    boundsAbove.push(item);
-                } else if (lastItem && item.top <= lastItem.bottom) {
-                    boundsBelow.push(item);
+            let lastBounds;
+            items.forEach(item => {
+                const bounds = item.bounds;
+                if (lastBounds && bounds.bottom <= lastBounds.top) {
+                    itemsAbove.push(item);
+                } else if (lastBounds && bounds.top >= lastBounds.bottom) {
+                    itemsBelow.push(item);
                 } else {
-                    lastItem = item;
-                    boundsInRow.push(item);
+                    lastBounds = bounds;
+                    itemsInRow.push(item);
                 }
             });
 
-            const resultsAbove = deriveFromBounds(boundsAbove);
-            let results = resultsAbove.length > 0 ? resultsAbove : [];
+            const resultsAbove = deriveRows(itemsAbove);
 
-            if (boundsInRow.length > 0) {
-                results.push(boundsInRow);
+            let results = resultsAbove;
+            if (itemsInRow.length > 0) {
+                results.push(itemsInRow);
             }
 
-            const resultsBelow = deriveFromBounds(boundsBelow);
+            const resultsBelow = deriveRows(itemsBelow);
             if (resultsBelow.length > 0) {
                 results = results.concat(resultsBelow);
             }


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2012

### Description
2nd round of bluescript fixes:
Add focusManager.derive2DNavigationArray() to derive navigation order from visual layout

### Testing
Run from Bluescript ads in skyline
Unit tests run as well

### Commit Message Subject(s)
CTV-2012: Framework for Runtime Implementation of Bluescript Behavior Tags

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
