### PR TITLE
Feature/ctv 2121 return previous focus when navigating from watch your show button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.67",
+  "version": "1.0.68",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -505,6 +505,10 @@ describe("TXMFocusManager", () => {
             });
 
             test("moving down from top chrome goes to first content focus", () => {
+                // establish last saved top focus for later
+                fm.navigateToNewFocus(inputActions.moveLeft);
+                expect(fm.currentFocus).toBe(topChrome[2]);
+
                 fm.navigateToNewFocus(inputActions.moveDown);
                 expect(fm.currentFocus).toBe(focuses[1]);
             });
@@ -535,21 +539,29 @@ describe("TXMFocusManager", () => {
                 expect(fm.currentFocus).toBe(bottomChrome[2]);
             });
 
-            test("moving up from bottom chrome moves to last content focus", () => {
+            test("moving up from bottom chrome moves to last saved content focus", () => {
                 fm.setContentFocusables([focuses[1], focuses[2], focuses[3]]);
+                fm.setFocus(focuses[2]);
+                fm.setFocus(bottomChrome[2]);
 
                 fm.navigateToNewFocus(inputActions.moveUp);
-                expect(fm.currentFocus).toBe(focuses[3]);
-            });
+                expect(fm.currentFocus).toBe(focuses[2]);
 
-            test("moving up from chrome moves to last top chrome focus", () => {
-                fm.navigateToNewFocus(inputActions.moveUp);
-                expect(fm.currentFocus).toBe(topChrome[3]);
-            });
-
-            test("moving back down from top chrome moves to first content focus again", () => {
                 fm.navigateToNewFocus(inputActions.moveDown);
-                expect(fm.currentFocus).toBe(focuses[1]);
+                expect(fm.currentFocus).toBe(bottomChrome[2]);
+
+                fm.navigateToNewFocus(inputActions.moveUp);
+                expect(fm.currentFocus).toBe(focuses[2]);
+            });
+
+            test("moving up from chrome moves to last saved top chrome focus", () => {
+                fm.navigateToNewFocus(inputActions.moveUp);
+                expect(fm.currentFocus).toBe(topChrome[2]);
+            });
+
+            test("moving back down from top chrome moves to last saved content focus again", () => {
+                fm.navigateToNewFocus(inputActions.moveDown);
+                expect(fm.currentFocus).toBe(focuses[2]);
             });
         });
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -45,13 +45,15 @@ export class TXMFocusManager {
         if (oldFocus === newFocus) return;
         if (oldFocus) {
             this._focus = undefined;
-            this._saveLastFocus(undefined, oldFocus);
             if (oldFocus.onFocusSet) oldFocus.onFocusSet(false);
         }
         if (newFocus) {
             this._focus = newFocus;
             this._saveLastFocus(newFocus, newFocus);
             if (newFocus.onFocusSet) newFocus.onFocusSet(true);
+        } else {
+            // We are clearing the focus completely.
+            this._saveLastFocus(undefined, oldFocus);
         }
     }
 
@@ -423,6 +425,7 @@ export class TXMFocusManager {
      * @param focusables array of focusable components, typically extending the {Focusable} class
      */
     setTopChromeFocusables(focusables) {
+        this._lastTopFocus = undefined;
         this._topChromeFocusables = this.ensure2DArray(focusables);
     }
 
@@ -431,6 +434,7 @@ export class TXMFocusManager {
      * @param focusables array of focusable components, typically extending the {Focusable} class
      */
     setBottomChromeFocusables(focusables) {
+        this._lastBottomFocus = undefined;
         this._bottomChromeFocusables = this.ensure2DArray(focusables);
     }
 
@@ -449,6 +453,7 @@ export class TXMFocusManager {
         const isInBottomChrome = this.findFocusPosition(current, this._bottomChromeFocusables);
         const resetFocus = !current || !isInTopChrome && !isInBottomChrome;
 
+        this._lastContentFocus = undefined;
         this._contentFocusables = this.ensure2DArray(focusables);
 
         if (resetFocus) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -92,6 +92,12 @@ export class TXMFocusManager {
     cleanup() {
         this.removeKeyEventListener();
         this.restoreBackActions();
+
+        // Release memory references
+        this._lastTopFocus = this._lastContentFocus = this._lastBottomFocus = undefined;
+        this._topChromeFocusables = [];
+        this._contentFocusables = [];
+        this._bottomChromeFocusables = [];
     }
 
     /**


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2121

### Description
Setting Automatic Focus to Previous Button/Step when Navigating from Watch Your Show Button

### Testing
Continued tests of Bluescript ads in skyline
Unit tests run as well

### Commit Message Subject(s)
CTV-2121: Setting Automatic Focus to Previous Button/Step when Navigating from Watch Your Show Button

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
