### PR TITLE
Feature/ctv 2152 use fire tv advertising id in vast config queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.72",
+  "version": "1.0.73",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.69",
+  "version": "1.0.70",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.71",
+  "version": "1.0.72",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.68",
+  "version": "1.0.69",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.70",
+  "version": "1.0.71",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -32,6 +32,13 @@ describe("TXMPlatform", () => {
             expect(platform.getInputAction(keyCodes.D)).toBe(inputActions.playPause);
             expect(platform.getInputAction(keyCodes.Q)).toBe(inputActions.leftShoulder1);
         });
+
+        test("default ad id support", () => {
+            expect(platform.supportsUserAdvertisingId).toBe(false);
+            return platform.getUserAdvertisingId().then(adId => {
+                expect(adId).toBe(undefined);
+            });
+        })
     });
 
     describe("FireTV Tests", () => {
@@ -62,6 +69,11 @@ describe("TXMPlatform", () => {
             expect(platform.getInputAction(keyCodes.rightArrow)).toBe(inputActions.moveRight);
             expect(platform.getInputAction(keyCodes.enter)).toBe(inputActions.select);
             expect(platform.getInputAction(keyCodes.esc)).toBe(inputActions.back);
+        });
+
+        test("ad id is supported", () => {
+            // We can't actually query the ad id from Jest, but we can ensure that it is assumed to be supported.
+            expect(platform.supportsUserAdvertisingId).toBe(true);
         });
     });
 

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -604,7 +604,8 @@ export class TXMPlatform {
     async getFireTVAdvertisingId() {
         let AmazonAdvertising = window.AmazonAdvertising;
         if (!AmazonAdvertising) {
-            const apiLoader = new ScriptLoader("http://resources.amazonwebapps.com/v1/latest/Amazon-Web-App-API.min.js");
+            const apiLoader = new ScriptLoader("https://resources.amazonwebapps.com/v1/latest/Amazon-Web-App-API.min.js");
+            apiLoader.load();
             await apiLoader.promise;
             AmazonAdvertising = await new Promise(resolve => {
                 document.addEventListener('amazonPlatformReady', onApiReady);

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -592,7 +592,14 @@ export class TXMPlatform {
         if (!AmazonAdvertising) {
             const apiLoader = new ScriptLoader("http://resources.amazonwebapps.com/v1/latest/Amazon-Web-App-API.min.js");
             await apiLoader.promise;
-            AmazonAdvertising = window.AmazonAdvertising;
+            AmazonAdvertising = await new Promise(resolve => {
+                document.addEventListener('amazonPlatformReady', onApiReady);
+
+                function onApiReady() {
+                    document.removeEventListener('amazonPlatformReady', onApiReady);
+                    resolve(window.AmazonAdvertising);
+                }
+            });
             if (!AmazonAdvertising) {
                 throw new Error("AmazonAdvertising API not available");
             }

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -98,6 +98,8 @@ export class TXMPlatform {
         let userAgent = userAgentOverride || window.navigator.userAgent;
         this.userAgent = userAgent;
 
+        this.supportsUserAdvertisingId = false;
+
         this._configure(userAgent);
     }
 
@@ -470,6 +472,14 @@ export class TXMPlatform {
             self.modelId = modelId;
 
             actionKeyCodes[inputActions.menu] = 18;
+
+            const webPlatformMatch = userAgent.match(/AmazonWebAppPlatform\/([0-9]+)/);
+            if (webPlatformMatch) {
+                // Advertising id query is only supported for web apps using the cordova framework, or else
+                // run with the Amazon Web App Tester.
+                const platformVersion = parseInt(webPlatformMatch[1]) || 0;
+                self.supportsUserAdvertisingId = platformVersion >= 3;
+            }
         }
 
         function configureForAndroidTV() {
@@ -580,6 +590,10 @@ export class TXMPlatform {
      * @return {Promise<String>}
      */
     async getUserAdvertisingId() {
+        if (!this.supportsUserAdvertisingId) {
+            return undefined;
+        }
+
         if (this.isFireTV) {
             return this.getFireTVAdvertisingId();
         }

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -634,8 +634,8 @@ export class TXMPlatform {
         return Promise.all([adIdPromise, adTrackingPromise])
         .then(results => {
             const adId = results[0];
-            const trackingPreference = results[1];
-            return adId && trackingPreference ? adId : undefined;
+            const limitTracking = results[1];
+            return adId && !limitTracking ? adId : undefined;
         });
     }
 }


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2152

### Description
* Implement fire tv device ad id query for web apps with Amazon api support.
* Implement userAdvertisingId option to allow host app to override ad id.

### Testing
Exercised ads from Skyline, view ad ids in the logs.
Unit tests run for ad id fallback defaults and ad id override TAR option.

### Commit Message Subject(s)
CTV-2152: use FireTV advertising id in vast config queries

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
