### PR TITLE
Bugfix/ctv 2149 firetv performance fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.73",
+  "version": "1.0.74",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -75,6 +75,15 @@ describe("TXMPlatform", () => {
             // We can't actually query the ad id from Jest, but we can ensure that it is assumed to be supported.
             expect(platform.supportsUserAdvertisingId).toBe(true);
         });
+
+        test("test firetv edition modle", () => {
+            const platform = new TXMPlatform("Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12 Build/NS6271; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0");
+            expect(platform.isFireTV).toBe(true);
+            expect(platform.name).toBe("FireTV");
+            expect(platform.model).toBe("Fire TV Edition - Insignia 4K (2018)");
+            expect(platform.modelId).toBe("AFTJMST12");
+            expect(platform.version).toBe("7.1.2");
+        });
     });
 
     describe("Android TV Tests", () => {

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -449,6 +449,8 @@ export class TXMPlatform {
             const modelMatch = userAgent.match(/\bAFT[A-Z0-9]+\b/);
             const modelId = modelMatch && modelMatch[0];
 
+            // Derived from https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
+            // NOTE: watch out for duplicates!
             const knownModels = {
                 AFTA: "Fire TV Cube (Gen 1)",
                 AFTB: "Fire TV (Gen 1)",

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -448,27 +448,32 @@ export class TXMPlatform {
             // From: https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
             const modelMatch = userAgent.match(/\bAFT[A-Z]+\b/);
             const modelId = modelMatch && modelMatch[0];
-            var model = "Fire TV";
-            if (modelId == "AFTN") {
-                model = "Fire TV (Gen 3)";
-            } else if (modelId == "AFTS") {
-                model = "Fire TV (Gen 2)";
-            } else if (modelId == "AFTB") {
-                model = "Fire TV (Gen 1)";
-            } else if (modelId == "AFTT") {
-                model = "Fire TV Stick (Gen 2)";
-            } else if (modelId == "AFTM") {
-                model = "Fire TV Stick (Gen 1)";
-            } else if (modelId == "AFTMM") {
-                model = "Fire TV Stick 4K";
-            } else if (modelId == "AFTRS") {
-                model = "Fire TV Edition";
-            } else if (modelId == "AFTA") {
-                model = "Fire TV Cube (Gen 1)";
-            } else if (modelId == "AFTR") {
-                model = "Fire TV Cube (Gen 2)";
-            }
-            self.model = model;
+
+            const knownModels = {
+                AFTDCT31: "Fire TV Edition - Toshiba 4K UHD (2020)",
+                AFTDCT31: "Fire TV Edition - Insignia 4K UHD (2020)",
+                AFTLE: "Fire TV Edition - Onida HD (2019)",
+                AFTR: "Fire TV Cube (Gen 2)",
+                AFTEUFF014: "Fire TV Edition - Grundig OLED 4K (2019)",
+                AFTEU014: "Fire TV Edition - Grundig Vision 7 4K (2019)",
+                AFTSO001: "Fire TV Edition - JVC 4K (2019)",
+                AFTMM: "Fire TV Edition - Nebula Soundbar (2019)",
+                AFTEU011: "Fire TV Edition - Grundig Vision 6 HD (2019)",
+                AFTKMST12: "Fire TV Edition - Toshiba 4K (2018/2019)",
+                AFTJMST12: "Fire TV Edition - Insignia 4K (2018)",
+                AFTBAMR311: "Fire TV Edition - Toshiba HD (2018-2020)",
+                AFTEAMR311: "Fire TV Edition - Insignia HD (2018-2020)",
+                AFTA: "Fire TV Cube (Gen 1)",
+                AFTN: "Fire TV (Gen 3)",
+                AFTMM: "Fire TV Stick 4K",
+                AFTRS: "Fire TV Edition - Element 4K (2017)",
+                AFTS: "Fire TV (Gen 2)",
+                AFTT: "Fire TV Stick (Gen 2)",
+                AFTM: "Fire TV Stick (Gen 1)",
+                AFTT: "Fire TV Stick (Basic Edition)",
+                AFTB: "Fire TV (Gen 1)"
+            };
+            self.model = knownModels[modelId] || "Fire TV";
             self.modelId = modelId;
 
             actionKeyCodes[inputActions.menu] = 18;

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -446,32 +446,29 @@ export class TXMPlatform {
             self.name = "FireTV";
 
             // From: https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
-            const modelMatch = userAgent.match(/\bAFT[A-Z]+\b/);
+            const modelMatch = userAgent.match(/\bAFT[A-Z0-9]+\b/);
             const modelId = modelMatch && modelMatch[0];
 
             const knownModels = {
-                AFTDCT31: "Fire TV Edition - Toshiba 4K UHD (2020)",
-                AFTDCT31: "Fire TV Edition - Insignia 4K UHD (2020)",
-                AFTLE: "Fire TV Edition - Onida HD (2019)",
-                AFTR: "Fire TV Cube (Gen 2)",
-                AFTEUFF014: "Fire TV Edition - Grundig OLED 4K (2019)",
-                AFTEU014: "Fire TV Edition - Grundig Vision 7 4K (2019)",
-                AFTSO001: "Fire TV Edition - JVC 4K (2019)",
-                AFTMM: "Fire TV Edition - Nebula Soundbar (2019)",
-                AFTEU011: "Fire TV Edition - Grundig Vision 6 HD (2019)",
-                AFTKMST12: "Fire TV Edition - Toshiba 4K (2018/2019)",
-                AFTJMST12: "Fire TV Edition - Insignia 4K (2018)",
-                AFTBAMR311: "Fire TV Edition - Toshiba HD (2018-2020)",
-                AFTEAMR311: "Fire TV Edition - Insignia HD (2018-2020)",
                 AFTA: "Fire TV Cube (Gen 1)",
-                AFTN: "Fire TV (Gen 3)",
+                AFTB: "Fire TV (Gen 1)",
+                AFTBAMR311: "Fire TV Edition - Toshiba HD (2018-2020)",
+                AFTDCT31: "Fire TV Edition - 4K UHD (2020)",
+                AFTEAMR311: "Fire TV Edition - Insignia HD (2018-2020)",
+                AFTEU011: "Fire TV Edition - Grundig Vision 6 HD (2019)",
+                AFTEU014: "Fire TV Edition - Grundig Vision 7 4K (2019)",
+                AFTEUFF014: "Fire TV Edition - Grundig OLED 4K (2019)",
+                AFTJMST12: "Fire TV Edition - Insignia 4K (2018)",
+                AFTKMST12: "Fire TV Edition - Toshiba 4K (2018/2019)",
+                AFTLE: "Fire TV Edition - Onida HD (2019)",
+                AFTM: "Fire TV Stick (Gen 1)",
                 AFTMM: "Fire TV Stick 4K",
+                AFTN: "Fire TV (Gen 3)",
+                AFTR: "Fire TV Cube (Gen 2)",
                 AFTRS: "Fire TV Edition - Element 4K (2017)",
                 AFTS: "Fire TV (Gen 2)",
-                AFTT: "Fire TV Stick (Gen 2)",
-                AFTM: "Fire TV Stick (Gen 1)",
-                AFTT: "Fire TV Stick (Basic Edition)",
-                AFTB: "Fire TV (Gen 1)"
+                AFTSO001: "Fire TV Edition - JVC 4K (2019)",
+                AFTT: "Fire TV Stick (Gen 2)"
             };
             self.model = knownModels[modelId] || "Fire TV";
             self.modelId = modelId;


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2194

### Description
Update known FireTV models to recognize Fire TV Edition models.

### Testing
Exercised video tester ad from Skyline, run unit tests.

### Commit Message Subject(s)
CTV-2194: Update known FireTV models to recognize Fire TV Edition models.

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
