### PR TITLE
Bugfix/ctv 2470 incorrect focus after replace step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## v1.0.76
+## v1.0.77
 
 * [CTV-2470](https://truextech.atlassian.net/browse/CTV-2470): The focus appeared to be incorrect after replace step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1.0.76
+
+* [CTV-2470](https://truextech.atlassian.net/browse/CTV-2470): The focus appeared to be incorrect after replace step.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.76",
+  "version": "1.0.77",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.75",
+  "version": "1.0.76",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -554,12 +554,29 @@ describe("TXMFocusManager", () => {
                 expect(fm.currentFocus).toBe(focuses[2]);
             });
 
+            test("moving up from bottom chrome moves to default content focus", () => {
+                // Start initially in the bottom chrome, simulate a replace step that resets the content.
+                fm.setFocus(bottomChrome[2]);
+                fm.setContentFocusables([focuses[1], focuses[2], focuses[3]], focuses[3]);
+
+                fm.navigateToNewFocus(inputActions.moveUp);
+                expect(fm.currentFocus).toBe(focuses[3]);
+
+                fm.navigateToNewFocus(inputActions.moveDown);
+                expect(fm.currentFocus).toBe(bottomChrome[2]);
+
+                fm.navigateToNewFocus(inputActions.moveUp);
+                expect(fm.currentFocus).toBe(focuses[3]);
+            });
+
             test("moving up from chrome moves to last saved top chrome focus", () => {
                 fm.navigateToNewFocus(inputActions.moveUp);
                 expect(fm.currentFocus).toBe(topChrome[2]);
             });
 
             test("moving back down from top chrome moves to last saved content focus again", () => {
+                fm.setFocus(topChrome[1]);
+                fm.setContentFocusables([focuses[1], focuses[2], focuses[3]], focuses[2]);
                 fm.navigateToNewFocus(inputActions.moveDown);
                 expect(fm.currentFocus).toBe(focuses[2]);
             });

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -58,11 +58,11 @@ export class TXMFocusManager {
     }
 
     _saveLastFocus(focusValue, forFocus) {
-        if (this.findFocusPosition(forFocus, this._topChromeFocusables)) {
+        if (this.isInTopChrome(forFocus)) {
             this._lastTopFocus = focusValue;
-        } else if (this.findFocusPosition(forFocus, this._contentFocusables)) {
+        } else if (this.isInContent(forFocus)) {
             this._lastContentFocus = focusValue;
-        } else if (this.findFocusPosition(forFocus, this._bottomChromeFocusables)) {
+        } else if (this.isInBottomChrome(forFocus)) {
             this._lastBottomFocus = focusValue;
         }
     }
@@ -449,15 +449,14 @@ export class TXMFocusManager {
     setContentFocusables(focusables, defaultFocus) {
         // Reset the current focus unless it is in the top or bottom chrome.
         const current = this.currentFocus;
-        const isInTopChrome = this.findFocusPosition(current, this._topChromeFocusables);
-        const isInBottomChrome = this.findFocusPosition(current, this._bottomChromeFocusables);
+        const isInTopChrome = this.isInTopChrome(current);
+        const isInBottomChrome = this.isInBottomChrome(current);
         const resetFocus = !current || !isInTopChrome && !isInBottomChrome;
 
         this._contentFocusables = this.ensure2DArray(focusables);
 
         // Mark the default content focus, but only if it is actually a valid content focusable.
-        this._lastContentFocus = this.findFocusPosition(defaultFocus, this._contentFocusables)
-            ? defaultFocus : undefined;
+        this._lastContentFocus = this.isInContent(defaultFocus) && defaultFocus;
 
         if (resetFocus) {
             this.setFocus(defaultFocus || this.getFirstFocus());
@@ -506,6 +505,18 @@ export class TXMFocusManager {
                 return component;
             }
         }
+    }
+
+    isInTopChrome(focusable) {
+        return !!this.findFocusPosition(focusable, this._topChromeFocusables);
+    }
+
+    isInContent(focusable) {
+        return !!this.findFocusPosition(focusable, this._contentFocusables);
+    }
+
+    isInBottomChrome(focusable) {
+        return !!this.findFocusPosition(focusable, this._bottomChromeFocusables);
     }
 
     findFocusPosition(focus, inFocusables) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -443,21 +443,24 @@ export class TXMFocusManager {
      * It is the developer's responsibility to call this during their page loading initialization.
      *
      * @param focusables array of focusable components, typically extending the {Focusable} class
-     * @param initialFocus specifies which focusable should be the initial current focus.
+     * @param defaultFocus specifies which focusable should be the initial current focus.
      *   If not specified, the first focusable is used.
      */
-    setContentFocusables(focusables, initialFocus) {
+    setContentFocusables(focusables, defaultFocus) {
         // Reset the current focus unless it is in the top or bottom chrome.
         const current = this.currentFocus;
         const isInTopChrome = this.findFocusPosition(current, this._topChromeFocusables);
         const isInBottomChrome = this.findFocusPosition(current, this._bottomChromeFocusables);
         const resetFocus = !current || !isInTopChrome && !isInBottomChrome;
 
-        this._lastContentFocus = undefined;
         this._contentFocusables = this.ensure2DArray(focusables);
 
+        // Mark the default content focus, but only if it is actually a valid content focusable.
+        this._lastContentFocus = this.findFocusPosition(defaultFocus, this._contentFocusables)
+            ? defaultFocus : undefined;
+
         if (resetFocus) {
-            this.setFocus(initialFocus || this.getFirstFocus());
+            this.setFocus(defaultFocus || this.getFirstFocus());
         }
     }
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2470

### Description
* Fixed focus manager to restore to step default focus when moving up from footer chrome if current step focus is not set.
* Invoke step "appear" callbacks before setting the step auto focus
* Fix 5092 Biden ad to reset focus planels on step appearance.

### Testing
Unit tests updated and passing.
Test from Skyline, 5092 qa ad runs, focus is present or not as required depending if user is in the ad, or in the chrome on "Return to Content".

### Commit Message Subject(s)
CTV-2470: The focus appeared to be incorrect after replace step

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
 