### PR TITLE
Bugfix/ctv 2491 fix default focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.78
+
+* [CTV-2491](https://truextech.atlassian.net/browse/CTV-2491): Should not auto focus the footer button
+
 ## v1.0.77
 
 * [CTV-2470](https://truextech.atlassian.net/browse/CTV-2470): The focus appeared to be incorrect after replace step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## v1.0.78
+## v1.0.79
 
 * [CTV-2491](https://truextech.atlassian.net/browse/CTV-2491): Should not auto focus the footer button
+
+## v1.0.78
+
+TBD from mikey
 
 ## v1.0.77
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 * [CTV-2491](https://truextech.atlassian.net/browse/CTV-2491): Should not auto focus the footer button
 
-## v1.0.78
-
-TBD from mikey
-
 ## v1.0.77
 
 * [CTV-2470](https://truextech.atlassian.net/browse/CTV-2470): The focus appeared to be incorrect after replace step.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.78",
+  "version": "1.0.79",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.77",
+  "version": "1.0.78",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -459,7 +459,12 @@ export class TXMFocusManager {
         this._lastContentFocus = this.isInContent(defaultFocus) && defaultFocus;
 
         if (resetFocus) {
-            this.setFocus(defaultFocus || this.getFirstFocus());
+            if (!defaultFocus) {
+                // Fallback to the first possible content focus.
+                // (We do not default to a top/bottom chrome focus.)
+                defaultFocus = this.getFirstFocusIn(this._contentFocusables);
+            }
+            this.setFocus(defaultFocus);
         }
     }
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2491

### Description
Do not use any chrome items for the default focus.

### Testing
Run the "National Association Of Realtors" from Skyline as per the ticket.
Unit tests pass.

### Commit Message Subject(s)
 CTV-2491: Should not auto focus the footer button

### Additional Context
n/a

### Related PRs

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
 
