### PR TITLE
CTV-2184 Updating decodeUrlParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.0.81
+## v1.0.82
 
 * [CTV-2184](https://truextech.atlassian.net/browse/CTV-2184): Added decodeUrlParams for parsing engagement urls.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.81",
+  "version": "1.0.82",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -1,4 +1,4 @@
-import { decodeUrlParams, encodeUrlParams } from '../url_params';
+import { parseQueryArgs, encodeUrlParams } from '../url_params';
 
 describe('encodeUrlParams', () => {
     it('should return a query string of key=value', () => {
@@ -12,9 +12,9 @@ describe('encodeUrlParams', () => {
     });
 });
 
-describe('decodeUrlParams', () => {
+describe('parseQueryArgs', () => {
     it('should return the params of the url', () => {
         const url = "www.test.com?a=1&b=2";
-        expect(decodeUrlParams(url, '&', '?')).toEqual({ a: '1', b: '2' });
+        expect(parseQueryArgs(url, '&', '?')).toEqual({ a: '1', b: '2' });
     });
 });

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -10,7 +10,7 @@ export function parseQueryArgs(url, separatorString = "&", paramChar = "?", deco
     const hashAt = url.indexOf(paramChar);
     let queryArgs = hashAt >= 0 && url.substr(hashAt+1);
     if (decodeArgs) {
-        queryArgs = (decodeURIComponent(queryArgs));
+        queryArgs = decodeURIComponent(queryArgs);
     }
     return parseArgs(queryArgs, separatorString);
 };

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -1,15 +1,27 @@
 /**
- * decodeUrlParams - converts a keyvalue object into URLEncoded params
- * @param {object} - object of key and its corresponding values
- * @returns {string} - urlencoded query string
+ * parseQueryArgs - parses the query args from a given url
+ * @url {string} - string of the url to parse the query args from
+ * @separatorString {string} - string to separate the query args by
+ * @paramChar {string} - string to split the url from the query args
+ * @decodeArgs {boolean} - boolean to determine decoding the query args
+ * @returns {object} - object of the query args
  */
-export function decodeUrlParams(url, splitString = "&", paramChar = "?") {
+export function parseQueryArgs(url, separatorString = "&", paramChar = "?", decodeArgs = false) {
     const hashAt = url.indexOf(paramChar);
-    const engagementQueryArgs = hashAt >= 0 && decodeURIComponent(url.substr(hashAt+1));
-    return parseQueryArgs(engagementQueryArgs, splitString);
+    let queryArgs = hashAt >= 0 && url.substr(hashAt+1);
+    if (decodeArgs) {
+        queryArgs = (decodeURIComponent(queryArgs));
+    }
+    return parseArgs(queryArgs, separatorString);
 };
 
-const parseQueryArgs = (queryArgs, splitString) => {
+/**
+ * parseArgs - converts a string of query args into an object
+ * @queryArgs {string} - string of the query args
+ * @separatorString {string} - string to separate the query args by
+ * @returns {object} - object of the query args
+ */
+export function parseArgs(queryArgs, splitString) {
     const result = {};
     if (queryArgs) {
         queryArgs.split(splitString).forEach(nameAndValue => {


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2184

### Description
Renaming the decodeUrlParams function and adding a param to conditionally decode the query args. Also exporting the parseArgs function

### Testing
Unit tests updated and passing.
Test from Skyline, verify tracking events are being sent with encoded params.

### Commit Message Subject(s)
CTV-2184: Updating url_params and decodeUrlParams

### Additional Context
OPTIONAL_ADDITIONAL_INFO

### Related PRs
https://github.com/socialvibe/container_core/pull/339
https://github.com/socialvibe/integration_core/pull/115
https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/58

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

