### PR TITLE
Fix (CTV-2491): Don't set default focus unless user inputs movement action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.83
+
+* [CTV-2491](https://truextech.atlassian.net/browse/CTV-2491): Default focus only set on user input for navigation/select.
+
 ## v1.0.82
 
 * [CTV-2184](https://truextech.atlassian.net/browse/CTV-2184): Added decodeUrlParams for parsing engagement urls.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.0.82",
+  "version": "1.0.83",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -262,7 +262,8 @@ export class TXMFocusManager {
         }
 
         let focus = this.currentFocus;
-        if (!focus && inputActions.isMovementAction(action)) {
+        // if no element is currently focused, and the user is attempting to navigate or select, set default focus
+        if (!focus && (inputActions.isMovementAction(action) || inputAction == inputActions.select)) {
             focus = this.getFirstFocus();
             this.setFocus(focus);
             return true;

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -262,7 +262,7 @@ export class TXMFocusManager {
         }
 
         let focus = this.currentFocus;
-        if (!focus) {
+        if (!focus && inputActions.isMovementAction(action)) {
             focus = this.getFirstFocus();
             this.setFocus(focus);
             return true;


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2491

### Description
Instead of allowing focus to be automatically set to the first focusable element when there exists no current focus, we only want to reset the focus when the user is attempting to navigate while no element currently has focus.

### Commit Message Subject(s)
`fix: set default focus only on navigation input`

### Checks
- [ ] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [ ] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

