### PR TITLE
put in reasonable exitApp method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.2.0
+## v1.2.1
 * [CTV-2658](https://truextech.atlassian.net/browse/CTV-2658): Tizen platform fixes
 
 ## v1.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -185,6 +185,27 @@ export class TXMPlatform {
         return this.describeError(error, true);
     }
 
+    exitApp() {
+        if (this.isTizen && window.tizen) {
+            window.tizen.application.getCurrentApplication().exit();
+            return;
+        }
+
+        if (this.isVizio && window.VIZIO && window.VIZIO.isSmartCastDevice) {
+            // we're using a smart cast TV do their exit call
+            window.VIZIO.exitApplication();
+            return;
+        }
+
+        // Fall back to something reasonable.
+        try {
+            window.close();
+        } catch (err) {}
+        try {
+            window.location = "about:blank";
+        } catch (err) {}
+    }
+
     _configure(userAgent) {
         const self = this;
         const actionKeyCodes = {};


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2658

### Description
Add platform.exitApp() to allow use from Skyline and the HTML5 reference apps.

### Testing
Run  from Skyline on the Tizen with a local build.

### Commit Message Subject(s)
CTV-2658: add platform.exitApp()

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [ ] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
