### PR TITLE
Bugfix/ctv 2721 lg support fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.2.2
+* [CTV-2721](https://truextech.atlassian.net/browse/CTV-2658): LG platform fixes
+
 ## v1.2.1
 * [CTV-2658](https://truextech.atlassian.net/browse/CTV-2658): Tizen platform fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -276,6 +276,13 @@ export class TXMPlatform {
             // This may cause the lower resolution to have scrollbar.
             self.useScrollTop = true;
 
+            // LG uses history back actions by default instead of the explicit back key event,
+            // although keystroke events can be enabled by adding `disableBackHistoryAPI: true;`
+            // to the `appinfo.json` web app's file.
+            //
+            // see https://webostv.developer.lge.com/develop/app-developer-guide/back-button/
+            self.useHistoryBackActions = true;
+
             addDefaultKeyMap();
             actionKeyCodes[inputActions.back] = 461;
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2721

### Description
Indicate LG TVs need history back processing.

### Testing
Run from Skyline

### Commit Message Subject(s)
CTV-2721: Test ads/behaviors on LG WebOS

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
