### PR TITLE
Bugfix/ctv 2681 only log failed loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.2.4
+* [CTV-2681](https://truextech.atlassian.net/browse/CTV-2681): Loader error logging
+
 ## v1.2.3
 * [CTV-2718](https://truextech.atlassian.net/browse/CTV-2718): Add PS5 support
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/utils/__tests__/loaders-test.js
+++ b/src/utils/__tests__/loaders-test.js
@@ -42,6 +42,20 @@ describe('BaseLoader Class', () => {
             expect(loader.onerror).toBeUndefined();
             loader.onerror = onerrorCB;
             expect(loader.onerror).toBeDefined();
+
+            const promise = loader.promise;
+            const testError = new Error('test error');
+            let warning;
+            console.warn = (...args) => {warning = args.join(' ')};
+            loader.__reject(testError, 1, 2);
+
+            return promise
+                .then(() => {})
+                .catch(err => {
+                    expect(err).toBe(testError);
+                    expect(onerrorCB).toHaveBeenCalled();
+                    expect(warning).toEqual('rejected http://google.com/track Error: test error 1 2');
+                });
         });
     });
 });

--- a/src/utils/__tests__/loaders-test.js
+++ b/src/utils/__tests__/loaders-test.js
@@ -50,7 +50,10 @@ describe('BaseLoader Class', () => {
             loader.__reject(testError, 1, 2);
 
             return promise
-                .then(() => {})
+                .then(() => {
+                    // should not get here
+                    expect(false).toBe(true);
+                })
                 .catch(err => {
                     expect(err).toBe(testError);
                     expect(onerrorCB).toHaveBeenCalled();

--- a/src/utils/loaders.js
+++ b/src/utils/loaders.js
@@ -27,10 +27,10 @@ export class BaseLoader {
             this._onLoadCB(...data);
         }
         this._resolve(...data);
-        console.warn('resolved', this._url);
     }
 
     __reject(...data) {
+        console.warn('rejected', this._url, ...data);
         if (this._onErrorCB) {
             this._onErrorCB(...data);
         }


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2681

### Description
Ensure all script instructions that target other elements can use expressions for the .target or .name attribute in the host instruction.

### Testing
Run from Skyline, exercise animation ad (creative 5162), notably the "@Random" button.
Run unit tests

### Commit Message Subject
CTV-2681: HTML5 - animateElement name does not compute BS values

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
