### PR TITLE
Feature/ctv 2881 use truex fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.3.0
+* [CTV-2881](https://truextech.atlassian.net/browse/CTV-2881): Define truex fonts
+
 ## v1.2.9
 * [CTV-2865](https://truextech.atlassian.net/browse/CTV-2899): Fixed a class export for DMP segment utility class
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.2.9",
+  "version": "1.3.0",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/components/truex-fonts.scss
+++ b/src/components/truex-fonts.scss
@@ -1,0 +1,28 @@
+// Establish standard truex fonts that be guaranteed to be available.
+
+// Currently just Gotham Bold.
+@font-face {
+  font-family: TruexBold;
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+  src: url("https://media.truex.com/file_assets/2021-06-17/1b48aafcd8bb4fd94d4288847d1454c8.otf") format("opentype");
+}
+
+// Currently just Gotham Medium.
+@font-face {
+  font-family: TruexNormal;
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+  src: url("https://media.truex.com/file_assets/2021-06-17/1ca7ee8ddb65dd9ce5c10ac7c8fa067b.otf") format("opentype");
+}
+
+// The bold version of TruexNormal is just TruexBold
+@font-face {
+  font-family: TruexNormal;
+  font-weight: bold;
+  font-style: normal;
+  font-display: block;
+  src: url("https://media.truex.com/file_assets/2021-06-17/1b48aafcd8bb4fd94d4288847d1454c8.otf") format("opentype");
+}


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2881

### Description
* Provide known TruexNormal and TruexBold fonts. Choice card and engagement now ensures these are always available, with TruexNormal being the default font.

* If the cw_footer_test test variant is active, the footer UX updates the interaction prompt and icon as per the timeout/credit/interactive state of the ad.

### Testing
* Run from Skyline, ran unit tests

### Commit Message Subject
CTV-2881: UI Prompt Updates

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
