### PR TITLE
Feature/ctv 2758 add vizio support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.3.1
+## v1.3.2
 * [CTV-2758](https://truextech.atlassian.net/browse/CTV-2758): Add Vizio support
 
 ## v1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.3.1
+* [CTV-2758](https://truextech.atlassian.net/browse/CTV-2758): Add Vizio support
+
 ## v1.3.0
 * [CTV-2881](https://truextech.atlassian.net/browse/CTV-2881): Define truex fonts
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": ["src"],

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -5,6 +5,7 @@ import { getElementPath }        from '../utils/get_element_path';
 
 import '../utils/uuid-polyfill';
 import { v4 as uuid } from 'uuid';
+import timedLog from "../utils/timed_log";
 
 /**
  * Defines a focus manager suitable for fielding remote control or keyboard events and directing them to an
@@ -42,8 +43,7 @@ export class TXMFocusManager {
 
     debugLog(msg) {
         if (this.debug) {
-            const time = new Date().toISOString().split('T')[1].replace(/Z$/, '');
-            console.log(`*** ${time} ${this.id} focusManager: ${msg}`);
+            timedLog(`*** ${time} ${this.id} focusManager: ${msg}`);
         }
     }
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -5,7 +5,7 @@ import { getElementPath }        from '../utils/get_element_path';
 
 import '../utils/uuid-polyfill';
 import { v4 as uuid } from 'uuid';
-import timedLog from "../utils/timed_log";
+import timedTrace from "../utils/timed_trace";
 
 /**
  * Defines a focus manager suitable for fielding remote control or keyboard events and directing them to an
@@ -43,7 +43,7 @@ export class TXMFocusManager {
 
     debugLog(msg) {
         if (this.debug) {
-            timedLog(`*** ${time} ${this.id} focusManager: ${msg}`);
+            timedTrace(`${this.id} focusManager: ${msg}`);
         }
     }
 

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -85,6 +85,9 @@ export class TXMPlatform {
         // Otherwise we rely on window.scrollTo, but that only works if we are not scaled.
         this.useWindowScroll = true;
 
+        this.supportsMouse = false;
+        this.supportsTouch = false;
+
         this.supportsGyro = false; // on all platforms except perhaps for the Switch?
 
         // Indicates if the platform player can start playback directly at a specified time position.
@@ -276,6 +279,8 @@ export class TXMPlatform {
             self.isLG = true;
             self.name = "LG";
 
+            self.supportsMouse = true;
+
             var webOS = window.webOS;
             if (webOS) {
                 webOS.deviceInfo(device => {
@@ -315,6 +320,8 @@ export class TXMPlatform {
         function configureForTizen() {
             self.isTizen = true;
             self.name = "Tizen";
+
+            self.supportsMouse = true;
 
             let versionMatch = userAgent.match(/Tizen ([^\s)]+)\)/);
             if (versionMatch) self.version = versionMatch[1];
@@ -451,6 +458,9 @@ export class TXMPlatform {
 
             self.model = "Windows.Xbox";
             self.version = "Unknown";
+
+            self.supportsMouse = true;
+            self.supportsTouch = true;
 
             // The Windows API is available only to UWP web apps, not regular web pages (or web views within a C# UWP app).
             // We want to tolerate both ways of making web apps for the Xbox.
@@ -602,6 +612,8 @@ export class TXMPlatform {
 
         function configureForUnknownPlatform() {
             self.isUnknown = true;
+            self.supportsMouse = true;
+            self.supportsTouch = true;
             addDefaultKeyMap();
             addTestingKeyCodes();
         }

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -75,6 +75,8 @@ export class TXMPlatform {
         this.isXboxOne = false;
         this.isNintendoSwitch = false;
 
+        this.isSlowDevice = false;
+
         // Scroll support:
 
         // If true (e.g. for LG WebOS), scrolling only works via scrollTop changes on a top level div.
@@ -369,6 +371,8 @@ export class TXMPlatform {
 
             const versionMatch = userAgent.match(/FW\/([^\s)]+)/);
             self.version = versionMatch && versionMatch[1] || "?.?.?";
+
+            self.isSlowDevice = !!self.model.match(/^D24/); // D-series has bad performance
 
             // disable to ensure scrollbars are always hidden in auto-scale situations.
             self.useWindowScroll = false;

--- a/src/utils/timed_log.js
+++ b/src/utils/timed_log.js
@@ -1,0 +1,6 @@
+export function timedLog(msg) {
+    const time = new Date().toISOString().split('T')[1].replace(/Z$/, '');
+    console.log(`*** ${time}: ${msg}`);
+}
+
+export default timedLog;

--- a/src/utils/timed_log.js
+++ b/src/utils/timed_log.js
@@ -1,6 +1,0 @@
-export function timedLog(msg) {
-    const time = new Date().toISOString().split('T')[1].replace(/Z$/, '');
-    console.log(`*** ${time}: ${msg}`);
-}
-
-export default timedLog;

--- a/src/utils/timed_trace.js
+++ b/src/utils/timed_trace.js
@@ -1,0 +1,19 @@
+
+var startTime = Date.now();
+
+export function resetTraceStart(newValue = Date.now()) {
+    startTime = newValue;
+}
+
+export function elapsedTrace(msg) {
+    const elapsed = (Date.now() - startTime) / 1000;
+    console.log(`*** ${elapsed.toFixed(3)}s: ${msg}`);
+}
+
+export function timedTrace(msg) {
+    const now = new Date();
+    const time = now.toISOString().split('T')[1].replace(/Z$/, '');
+    console.log(`*** ${time}: ${msg}`);
+}
+
+export default timedTrace;


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2758

### Description
* Ensure ads run on Vizio
** Avoid simultaneous video and/or audio
** Ensure desktop controllers and renderers load "immediately" as part of wepback load

### Testing
* Run from video and audio test ads from Skyline, ran unit tests

### Commit Message Subject
CTV-2758: Test ads/behaviors on Vizio

### Additional Context
n/a

### Related PRs

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
