### PR TITLE
Bugfix/ctv 3036 sticky key detection and interaction capping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.3.8
+## v1.3.9
 * [CTV-3036](https://truextech.atlassian.net/browse/CTV-3036): Sticky Key Detection and Interaction Capping
 
 ## v1.3.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -154,6 +154,19 @@ describe("TXMFocusManager", () => {
         });
     });
 
+    test("key event throttling", ()=> {
+        const fm = new TXMFocusManager();
+        fm.keyThrottleDelay = 100; // ensure throttling for this test
+        fm.onInputAction = jest.fn();
+        fm.onKeyDown(keyEvent);
+        expect(fm.onInputAction).toHaveBeenCalledTimes(1);
+        fm.onKeyDown(keyEvent);
+        fm.onKeyDown(keyEvent);
+        fm.onKeyDown(keyEvent);
+        fm.onKeyDown(keyEvent);
+        expect(fm.onInputAction).toHaveBeenCalledTimes(1);
+    });
+
     test("focus manager onInputAction callback", () => {
         const fm = new TXMFocusManager();
         fm.keyThrottleDelay = 0; // disable throttling for this test

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -114,6 +114,7 @@ describe("TXMFocusManager", () => {
 
     describe("focus manager optional onSelectAction callback", () => {
         const fm = new TXMFocusManager();
+        fm.keyThrottleDelay = 0; // disable throttling for this test
 
         test("onSelectAction callback should only happen on focus1", () => {
             focus1.onSelectAction = jest.fn();
@@ -155,6 +156,7 @@ describe("TXMFocusManager", () => {
 
     test("focus manager onInputAction callback", () => {
         const fm = new TXMFocusManager();
+        fm.keyThrottleDelay = 0; // disable throttling for this test
 
         focus1.onSelectAction = undefined;
         focus2.onSelectAction = undefined;
@@ -184,6 +186,7 @@ describe("TXMFocusManager", () => {
         jest.setTimeout(10 * 1000);
 
         const fm = new TXMFocusManager();
+        fm.keyThrottleDelay = 0; // disable throttling for this test
         fm.setFocus(focus1);
 
         const injectedActions = [];

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -244,8 +244,6 @@ export class TXMFocusManager {
     }
 
     onKeyDown(event) {
-        let handled = false;
-
         let keyCode = event.keyCode;
 
         const throttleDelay = this.keyThrottleDelay;
@@ -257,11 +255,12 @@ export class TXMFocusManager {
             this._lastKeyEventTimestamp = now;
             if (keyCode == this._lastKeyCode && elapsedTime <= throttleDelay) {
                 // Swallow the excess key event.
-                return;
+                return true; // handled
             }
             this._lastKeyCode = keyCode;
         }
 
+        let handled = false;
         let inputAction = this.platform.getInputAction(keyCode);
 
         if (this.debug) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -31,6 +31,10 @@ export class TXMFocusManager {
         this._handlesAllInputs = false; // input handling bubbles up default
         this._oldActiveElement = undefined;
 
+        // Set to 0 to disable throttling.
+        this.keyThrottleDelay = 100; // milliseconds
+        this._lastKeyCode = undefined;
+        this._lastKeyEventTimestamp = 0;
 
         // make convenient for direct callbacks
         this.onKeyDown = this.onKeyDown.bind(this);
@@ -243,6 +247,21 @@ export class TXMFocusManager {
         let handled = false;
 
         let keyCode = event.keyCode;
+
+        const throttleDelay = this.keyThrottleDelay;
+        if (throttleDelay > 0) {
+            // We are throttling key presses that happen too fast, e.g. when holding down a key on the remote.
+            // Otherwise too much processing and tracking happens.
+            const now = Date.now();
+            const elapsedTime = now - this._lastKeyEventTimestamp;
+            this._lastKeyEventTimestamp = now;
+            if (keyCode == this._lastKeyCode && elapsedTime <= throttleDelay) {
+                // Swallow the excess key event.
+                return;
+            }
+            this._lastKeyCode = keyCode;
+        }
+
         let inputAction = this.platform.getInputAction(keyCode);
 
         if (this.debug) {


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3036

### Description
Filter out identical key events that happen too quickly, i.e. "waves" of key down events due to holding down a remote control key.

### Testing
Ran new unit test, tested from Skyline on Chrome, and FireTV.

### Commit Message Subject
CTV-3036: HTML5 - Sticky Key Detection and Interaction Capping

### Additional Context

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
