### PR TITLE
Task/ctv 3205 support preprod builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.5.1
+* [CTV-3205](https://truextech.atlassian.net/browse/CTV-3205): HTML5 - Preproduction Environment
+
 ## v1.5.0
 * [CTV-3162](https://truextech.atlassian.net/browse/CTV-3162): Ads can programmatically set key event throttle threshold
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.5.3
+## v1.5.4
 * [CTV-3205](https://truextech.atlassian.net/browse/CTV-3205): HTML5 - Preproduction Environment
 
 ## v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.5.2
+## v1.5.3
 * [CTV-3205](https://truextech.atlassian.net/browse/CTV-3205): HTML5 - Preproduction Environment
 
 ## v1.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.5.1
+## v1.5.2
 * [CTV-3205](https://truextech.atlassian.net/browse/CTV-3205): HTML5 - Preproduction Environment
 
 ## v1.5.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -20,6 +20,9 @@ describe("truex_servers testing", () => {
     test("truex servers", () => {
         verifyServers(new TruexServers(false), false);
         verifyServers(new TruexServers(true), true);
+        verifyServers(new TruexServers(), false);
+        verifyServers(new TruexServers(null), false);
+        verifyServers(new TruexServers({}), false);
 
         const hiltonAd = "https://qa-get.truex.com/15c7f5269a09bd8c5007ba98263571dd80c458e5/vast/config?dimension_2=0&dimension_5=hilton&stream_position=preroll&stream_id=1234";
         verifyServers(new TruexServers(hiltonAd), false);

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -13,6 +13,8 @@ describe("truex_servers testing", () => {
         expect(isTruexProductionUrl("https://qa-media.truex.com")).toBe(false);
         expect(isTruexProductionUrl("https://qa-server.truex.com")).toBe(false);
         expect(isTruexProductionUrl("https://media.somewhere.else.com")).toBe(false);
+        expect(isTruexProductionUrl("qa-media.truex.com")).toBe(false);
+        expect(isTruexProductionUrl("media.truex.com")).toBe(true);
     });
 
     test("truex servers", () => {

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -33,6 +33,15 @@ describe("truex_servers testing", () => {
         const prodConfig = {ads: [{window_url: "https://media.truex.com/container/3.x/current/desktop/?whatever=1234"}]}
         verifyServers(new TruexServers(prodConfig), true);
 
+        const skipCardConfig = {ads: [], "card_creative_url": "https://media.truex.com/integration/ctv/choicecard-ctv.js"};
+        verifyServers(new TruexServers(skipCardConfig), true);
+
+        const skipCardConfig2 = {ads: [], "card_creative_url": "https://qa-media.truex.com/integration/ctv/choicecard-ctv.js"};
+        verifyServers(new TruexServers(skipCardConfig2), false);
+
+        const demoConfig = {ads: [], "service_url": "measure.truex.com"};
+        verifyServers(new TruexServers(demoConfig), true);
+
         function verifyServers(servers, isProd) {
             expect(servers.isProduction).toBe(isProd);
 

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -33,6 +33,9 @@ describe("truex_servers testing", () => {
 
             expect(servers.serverUrlOf("something.elsewhere.com")).toBe("https://something.elsewhere.com");
             expect(servers.serverUrlOf("http://localhost:8080")).toBe("http://localhost:8080");
+            expect(servers.serverUrlOf("http://qa-media.truex.com")).toBe("http://qa-media.truex.com");
+            expect(servers.serverUrlOf("https://qa-media.truex.com")).toBe("https://qa-media.truex.com");
+            expect(servers.serverUrlOf("//qa-media.truex.com")).toBe("https://qa-media.truex.com");
 
             if (isProd) {
                 expect(servers.truexServerUrl).toBe("https://serve.truex.com");

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -16,6 +16,9 @@ describe("truex_servers testing", () => {
     });
 
     test("truex servers", () => {
+        verifyServers(new TruexServers(false), false);
+        verifyServers(new TruexServers(true), true);
+
         const hiltonAd = "https://qa-get.truex.com/15c7f5269a09bd8c5007ba98263571dd80c458e5/vast/config?dimension_2=0&dimension_5=hilton&stream_position=preroll&stream_id=1234";
         verifyServers(new TruexServers(hiltonAd), false);
 

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -33,9 +33,10 @@ describe("truex_servers testing", () => {
 
             expect(servers.serverUrlOf("something.elsewhere.com")).toBe("https://something.elsewhere.com");
             expect(servers.serverUrlOf("http://localhost:8080")).toBe("http://localhost:8080");
+            expect(servers.serverUrlOf("qa-media.truex.com")).toBe("https://qa-media.truex.com");
+            expect(servers.serverUrlOf("//qa-media.truex.com")).toBe("https://qa-media.truex.com");
             expect(servers.serverUrlOf("http://qa-media.truex.com")).toBe("http://qa-media.truex.com");
             expect(servers.serverUrlOf("https://qa-media.truex.com")).toBe("https://qa-media.truex.com");
-            expect(servers.serverUrlOf("//qa-media.truex.com")).toBe("https://qa-media.truex.com");
 
             if (isProd) {
                 expect(servers.truexServerUrl).toBe("https://serve.truex.com");

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -1,0 +1,50 @@
+import { isTruexProductionUrl, TruexServers } from '../truex_servers';
+
+describe("truex_servers testing", () => {
+    test("isTruexProductionUrl", () => {
+        expect(isTruexProductionUrl()).toBe(false);
+        expect(isTruexProductionUrl("127.0.0.1")).toBe(false);
+        expect(isTruexProductionUrl("http://localhost:8080")).toBe(false);
+        expect(isTruexProductionUrl("http://media.truex.com")).toBe(true);
+        expect(isTruexProductionUrl("https://media.truex.com")).toBe(true);
+        expect(isTruexProductionUrl("https://measure.truex.com")).toBe(true);
+        expect(isTruexProductionUrl("https://server.truex.com")).toBe(true);
+        expect(isTruexProductionUrl("http://qa-media.truex.com")).toBe(false);
+        expect(isTruexProductionUrl("https://qa-media.truex.com")).toBe(false);
+        expect(isTruexProductionUrl("https://qa-server.truex.com")).toBe(false);
+        expect(isTruexProductionUrl("https://media.somewhere.else.com")).toBe(false);
+    });
+
+    test("truex servers", () => {
+        const hiltonAd = "https://qa-get.truex.com/15c7f5269a09bd8c5007ba98263571dd80c458e5/vast/config?dimension_2=0&dimension_5=hilton&stream_position=preroll&stream_id=1234";
+        verifyServers(new TruexServers(hiltonAd), false);
+
+        const multiVideosProd = "https://get.truex.com/72904fe382372efcdcea6314aa1d7a37db6051b9/vast/config?dimension_1=#e{series.title}&dimension_2=#{slot.position}&dimension_3=#e{asset.title}&dimension_4=#e{asset.id}&dimension_5=truex_sold&stream_position=midroll&stream_id=#{request.videoRandom}";
+        verifyServers(new TruexServers(multiVideosProd), true);
+
+        const qaConfig = {ads: [{window_url: "https://qa-media.truex.com/container/3.x/current/desktop/?whatever=1234"}]}
+        verifyServers(new TruexServers(qaConfig), false);
+
+        const prodConfig = {ads: [{window_url: "https://media.truex.com/container/3.x/current/desktop/?whatever=1234"}]}
+        verifyServers(new TruexServers(prodConfig), true);
+
+        function verifyServers(servers, isProd) {
+            expect(servers.isProduction).toBe(isProd);
+
+            expect(servers.serverUrlOf("something.elsewhere.com")).toBe("https://something.elsewhere.com");
+            expect(servers.serverUrlOf("http://localhost:8080")).toBe("http://localhost:8080");
+
+            if (isProd) {
+                expect(servers.truexServerUrl).toBe("https://serve.truex.com");
+                expect(servers.mediaServerUrl).toBe("https://media.truex.com");
+                expect(servers.measureServerUrl).toBe("https://measure.truex.com");
+                expect(servers.serverUrlOf("something.truex.com")).toBe("https://something.truex.com");
+            } else {
+                expect(servers.truexServerUrl).toBe("https://qa-serve.truex.com");
+                expect(servers.mediaServerUrl).toBe("https://qa-media.truex.com");
+                expect(servers.measureServerUrl).toBe("https://qa-measure.truex.com");
+                expect(servers.serverUrlOf("something.truex.com")).toBe("https://qa-something.truex.com");
+            }
+        }
+    });
+});

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -17,13 +17,13 @@ export class TruexServers {
     constructor(vastConfigOrUrlOrFlag) {
         var isProd = false; // by default
 
-        if (vastConfigOrUrlOrFlag === true) {
-            isProd = true;
+        if (typeof vastConfigOrUrlOrFlag == 'boolean') {
+            isProd = vastConfigOrUrlOrFlag;
 
         } else if (typeof vastConfigOrUrlOrFlag == 'string') {
             isProd = isTruexProductionUrl(vastConfigOrUrlOrFlag);
 
-        } else {
+        } else if (vastConfigOrUrlOrFlag) {
             const vc = vastConfigOrUrlOrFlag;
             const firstAd = vc && vc.ads && vc.ads[0];
             isProd = isTruexProductionUrl(firstAd && firstAd.window_url || vc.card_creative_url || vc.service_url);

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -17,7 +17,6 @@ export class TruexServers {
     constructor(vastConfigOrUrlOrFlag) {
         var isProd = false; // by default
 
-        var firstAd;
         if (vastConfigOrUrlOrFlag === true) {
             isProd = true;
 
@@ -25,9 +24,12 @@ export class TruexServers {
             isProd = isTruexProductionUrl(vastConfigOrUrlOrFlag);
 
         } else {
-            firstAd = vastConfigOrUrlOrFlag && vastConfigOrUrlOrFlag.ads && vastConfigOrUrlOrFlag.ads[0];
+            const vc = vastConfigOrUrlOrFlag;
+            const firstAd = vc && vc.ads && vc.ads[0];
             if (firstAd) {
                 isProd = isTruexProductionUrl(firstAd.window_url);
+            } else {
+                isProd = isTruexProductionUrl(vc.card_creative_url || vc.service_url);
             }
         }
 

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -14,15 +14,18 @@ export function isTruexProductionUrl(url) {
  * Describes various qa vs production versions of some key truex backend servers
  */
 export class TruexServers {
-    constructor(vastConfigOrUrl) {
+    constructor(vastConfigOrUrlOrFlag) {
         var isProd = false; // by default
 
         var firstAd;
-        if (typeof vastConfigOrUrl == 'string') {
-            isProd = isTruexProductionUrl(vastConfigOrUrl);
+        if (vastConfigOrUrlOrFlag === true) {
+            isProd = true;
+
+        } else if (typeof vastConfigOrUrlOrFlag == 'string') {
+            isProd = isTruexProductionUrl(vastConfigOrUrlOrFlag);
 
         } else {
-            firstAd = vastConfigOrUrl && vastConfigOrUrl.ads && vastConfigOrUrl.ads[0];
+            firstAd = vastConfigOrUrlOrFlag && vastConfigOrUrlOrFlag.ads && vastConfigOrUrlOrFlag.ads[0];
             if (firstAd) {
                 isProd = isTruexProductionUrl(firstAd.window_url);
             }

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -39,11 +39,17 @@ export class TruexServers {
         function serverUrlOf(host) {
             var result = host;
             const qaPrefix = 'qa-';
-            if (!isProd && !host.startsWith(qaPrefix) && host.indexOf('truex.com') >= 0) {
+            const hasProtocol = host.match(/^[a-zA-Z]+:\/\//);
+            const hasImplicitProtocol = host.match(/^\/\//);
+            if (!isProd && !hasProtocol && !hasImplicitProtocol
+                && !host.startsWith(qaPrefix) && host.indexOf('truex.com') >= 0) {
                 result = qaPrefix + host;
             }
-            if (!result.startsWith('http')) {
-                result = 'https://' + result;
+            if (!hasProtocol) {
+                if (!hasImplicitProtocol) {
+                    result = '//' + result;
+                }
+                result = 'https:' + result;
             }
             return result;
         }

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -26,11 +26,7 @@ export class TruexServers {
         } else {
             const vc = vastConfigOrUrlOrFlag;
             const firstAd = vc && vc.ads && vc.ads[0];
-            if (firstAd) {
-                isProd = isTruexProductionUrl(firstAd.window_url);
-            } else {
-                isProd = isTruexProductionUrl(vc.card_creative_url || vc.service_url);
-            }
+            isProd = isTruexProductionUrl(firstAd && firstAd.window_url || vc.card_creative_url || vc.service_url);
         }
 
         this.isProduction = isProd;

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -1,0 +1,51 @@
+
+export function isTruexProductionUrl(url) {
+    if (url) {
+        const m = url.match(/^(https?:\/\/)?([a-z])+.truex.com/);
+        if (m) {
+            if (m[2].startsWith('qa-')) return false;
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Describes various qa vs production versions of some key truex backend servers
+ */
+export class TruexServers {
+    constructor(vastConfigOrUrl) {
+        var isProd = false; // by default
+
+        var firstAd;
+        if (typeof vastConfigOrUrl == 'string') {
+            isProd = isTruexProductionUrl(vastConfigOrUrl);
+
+        } else {
+            firstAd = vastConfigOrUrl && vastConfigOrUrl.ads && vastConfigOrUrl.ads[0];
+            if (firstAd) {
+                isProd = isTruexProductionUrl(firstAd.window_url);
+            }
+        }
+
+        this.isProduction = isProd;
+
+        this.truexServerUrl = serverUrlOf('serve.truex.com');
+        this.mediaServerUrl = serverUrlOf('media.truex.com');
+        this.measureServerUrl = serverUrlOf('measure.truex.com');
+
+        this.serverUrlOf = serverUrlOf;
+
+        function serverUrlOf(host) {
+            var result = host;
+            const qaPrefix = 'qa-';
+            if (!isProd && !host.startsWith(qaPrefix) && host.indexOf('truex.com') >= 0) {
+                result = qaPrefix + host;
+            }
+            if (!result.startsWith('http')) {
+                result = 'https://' + result;
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3205

### Description
* Migrate away from build time qa vs prod server knowledge
* It is now driven only by the use of QA vs PROD ads
* Build prod versions for release builds.
* Build tar.min.js prod version for preprod TAR

### Testing
* Unit testing
* Ran from Skyline with the "task/CTV-3205-support-preprod-builds" feature branch to verify qa truex biulds.
* Ran from Skyline with the "release/1-5-0" feature branch to verify prod truex builds.

### Commit Message Subject
CTV-3205: HTML5 - Preproduction Environment

### Additional Context

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
