### PR TITLE
Task/ctv 3257 ad loaded spinner fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.4.1
+* [CTV-3257](https://truextech.atlassian.net/browse/CTV-3257): HTML5 adStarted event fires too early
+
 ## v1.4.0
 * [CTV-2979](https://truextech.atlassian.net/browse/CTV-2979): Add adFetchCompleted TAR event
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/events/txm_ad_events.js
+++ b/src/events/txm_ad_events.js
@@ -1,5 +1,6 @@
 const adEvents = {
     adStarted: 'adStarted',
+    adLoaded: 'adLoaded',
     adCompleted: 'adCompleted',
     adError: 'adError',
     noAdsAvailable: 'noAdsAvailable',

--- a/src/events/txm_ad_events.js
+++ b/src/events/txm_ad_events.js
@@ -1,6 +1,6 @@
 const adEvents = {
     adStarted: 'adStarted',
-    adLoaded: 'adLoaded',
+    adDisplayed: 'adDisplayed',
     adCompleted: 'adCompleted',
     adError: 'adError',
     noAdsAvailable: 'noAdsAvailable',


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3257

### Description
* add adDisplayed event, now emitted from choice card when images are all loaded
* show a loading spinner by default in choice card, unless options.showLoadingSpinner is false

### Testing
* Run from Skyline, Run from firetv-webview
* Unit tests still pass, but are not strictly related.

### Commit Message Subject
CTV-3257: HTML5 adStarted event fires too early

### Additional Context

### Related PRs
truex-shared: https://github.com/socialvibe/truex-shared-js/pull/52
bluescript: https://github.com/socialvibe/truex-bluescript-js/pull/60
c3: https://github.com/socialvibe/container_core/pull/475
ic: https://github.com/socialvibe/integration_core/pull/249
TAR: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/102
Skyline: https://github.com/socialvibe/Skyline/pull/237
firetv-webview: https://github.com/socialvibe/firetv-webview-webapp/pull/56

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
