### PR TITLE
Bugfix/ctv 2685 focus should not be reset during focus lost on button opacity changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.5.7
+* [CTV-2685](https://truextech.atlassian.net/browse/CTV-2685): HTML5 - focus should not be reset during focus lost on button opacity changes
+
 ## v1.5.5
 * [CTV-3257](https://truextech.atlassian.net/browse/CTV-3257): HTML5 adStarted event fires too early
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -58,12 +58,9 @@ export class TXMFocusManager {
     setFocus(newFocus) {
         let oldFocus = this.currentFocus;
         if (oldFocus === newFocus) return;
-        if (oldFocus) {
-            this._focus = undefined;
-            if (oldFocus.onFocusSet) oldFocus.onFocusSet(false);
-        }
+        this._focus = newFocus || undefined;
+        if (oldFocus && oldFocus.onFocusSet) oldFocus.onFocusSet(false);
         if (newFocus) {
-            this._focus = newFocus;
             this._saveLastFocus(newFocus, newFocus);
             if (newFocus.onFocusSet) newFocus.onFocusSet(true);
         } else {


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2685

### Description
* Fix bad focus change due to opacity change
* Reset possible focusables only when needed
* New current focus is now known during onFocusLost handling
* This allowe it to be maintain on possible focus resets.

### Testing
* Run creative ad 5284 from Skyline in Chrome, unit tests.

### Commit Message Subject
CTV-2685: HTML5 - focus should not be reset during focus lost on button opacity changes

### Additional Context

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
