### PR TITLE
Bugfix/ctv 3307 ensure consistent focus navigation rules for bluescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.6.0
+## v1.6.2
 * [CTV-3307](https://truextech.atlassian.net/browse/CTV-3307): HTML5: ensure consistent focus navigation rules for bluescript
 
 ## v1.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.5.8
+* [CTV-3307](https://truextech.atlassian.net/browse/CTV-3307): HTML5: ensure consistent focus navigation rules for bluescript
+
 ## v1.5.7
 * [CTV-2685](https://truextech.atlassian.net/browse/CTV-2685): HTML5 - focus should not be reset during focus lost on button opacity changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.5.8
+## v1.6.0
 * [CTV-3307](https://truextech.atlassian.net/browse/CTV-3307): HTML5: ensure consistent focus navigation rules for bluescript
 
 ## v1.5.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.8",
+  "version": "1.6.0",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/__tests__/derived-focus-navigation-test.js
+++ b/src/focus_manager/__tests__/derived-focus-navigation-test.js
@@ -3,7 +3,13 @@ import { Focusable } from "../txm_focusable";
 import { inputActions } from "../txm_input_actions";
 
 describe("derived 2D focus navigation", () => {
-  const fm = new TXMFocusManager();
+
+  const focusManager = new TXMFocusManager();
+
+  const up = inputActions.moveUp;
+  const down = inputActions.moveDown;
+  const left = inputActions.moveLeft;
+  const right = inputActions.moveRight;
 
   function newFocusable({id, x, y, w, h}) {
     const element = {id, top: y, left: x, bottom: y + h, right: x + w, width: w, height: h};
@@ -16,12 +22,12 @@ describe("derived 2D focus navigation", () => {
   }
 
   function testInput(currFocus, action, newFocus) {
-    fm.setFocus(currFocus);
-    fm.onInputAction(action);
-    expect(fm.currentFocus).toBe(newFocus);
+    focusManager.setFocus(currFocus);
+    focusManager.onInputAction(action);
+    expect(focusManager.currentFocus).toBe(newFocus);
   }
 
-  test("test focus grid with overlaps", () => {
+  test("test focus grid with overlaps, gaps", () => {
     // NOTE: overlaps are ignored, row/col based solely on top/left position.
     const f_0_0 = newFocusable({id: "f_0_0", x: 10, y: 10, w: 40, h: 40});
     const f_0_2 = newFocusable({id: "f_0_2", x: 60, y: 10, w: 40, h: 50});
@@ -32,7 +38,8 @@ describe("derived 2D focus navigation", () => {
     const f_3_3 = newFocusable({id: "f_3_3", x: 80, y: 80, w: 40, h: 40});
     const f_4_5 = newFocusable({id: "f_4_5", x: 200, y: 400, w: 40, h: 40});
 
-    const focusableGrid = fm.derive2DNavigationArray([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
+    // Note: all focusables get sorted into rows by increasing y, each row into columns by increasing x.
+    const focusableGrid = focusManager.derive2DNavigationArray([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
     expect(focusableGrid).toEqual([
       [f_0_0,     undefined, f_0_2],
       [undefined, undefined, f_1_2],
@@ -40,18 +47,177 @@ describe("derived 2D focus navigation", () => {
       [f_3_0,     f_3_1,     undefined, f_3_3],
       [undefined, undefined, undefined, undefined, undefined, f_4_5]
     ]);
+    focusManager.setContentFocusables(focusableGrid);
 
     // Moving along the same row or column takes precedence.
-    testInput(f_0_0, inputActions.moveDown, f_3_1);
-    testInput(f_3_1, inputActions.moveUp, f_0_0);
-    testInput(f_0_0, inputActions.moveRight, f_0_2);
-    testInput(f_0_2, inputActions.moveDown, f_1_2);
-    testInput(f_1_2, inputActions.moveUp, f_0_2);
-    testInput(f_1_2, inputActions.moveDown, f_2_4);
-    testInput(f_2_4, inputActions.moveUp, f_1_2);
-    testInput(f_2_4, inputActions.moveLeft, f_1_2);
-    testInput(f_2_4, inputActions.moveRight, f_4_5);
-    testInput(f_3_1, inputActions.moveRight, f_3_3);
-    testInput(f_3_3, inputActions.moveLeft, f_3_1);
+    testInput(f_0_0, down, f_3_1);
+    testInput(f_3_1, up, f_0_0);
+    testInput(f_0_0, right, f_0_2);
+    testInput(f_0_2, down, f_1_2);
+    testInput(f_1_2, up, f_0_2);
+    testInput(f_1_2, down, f_2_4);
+    testInput(f_2_4, up, f_1_2);
+    testInput(f_2_4, left, f_1_2);
+    testInput(f_2_4, right, f_4_5);
+    testInput(f_3_1, right, f_3_3);
+    testInput(f_3_3, left, f_3_1);
+  });
+
+  test("test simple focus grid", () => {
+    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 30, y: 10, w: 10, h: 10});
+    const C = newFocusable({id: "C", x: 50, y: 10, w: 10, h: 10});
+    const D = newFocusable({id: "D", x: 10, y: 30, w: 10, h: 10});
+    const E = newFocusable({id: "E", x: 30, y: 30, w: 10, h: 10});
+    const F = newFocusable({id: "F", x: 50, y: 30, w: 10, h: 10});
+
+    const focusableGrid = focusManager.derive2DNavigationArray([A, B, C, D, E, F]);
+    expect(focusableGrid).toEqual([
+      [A, B, C],
+      [D, E, F],
+    ]);
+    focusManager.setContentFocusables(focusableGrid);
+
+    testInput(A, down, D);
+    testInput(D, up, A);
+    testInput(A, right, B);
+    testInput(B, right, C);
+    testInput(C, right, C);
+    testInput(C, down, F);
+    testInput(F, left, E);
+    testInput(E, up, B);
+    testInput(B, down, E);
+    testInput(E, left, D);
+  });
+
+  test("test A kitty corner B", () => {
+    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
+
+    const focusableGrid = focusManager.derive2DNavigationArray([A, B]);
+    expect(focusableGrid).toEqual([
+      [A],
+      [undefined, B],
+    ]);
+    focusManager.setContentFocusables(focusableGrid);
+
+    testInput(A, down, B);
+    testInput(A, right, B);
+    testInput(B, up, A);
+    testInput(B, right, A);
+    testInput(B, right, B);
+    testInput(A, up, A);
+  });
+
+  test("test button square with center", () => {
+    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 100, y: 10, w: 10, h: 10});
+    const C = newFocusable({id: "C", x: 50, y: 50, w: 10, h: 10});
+    const D = newFocusable({id: "D", x: 10, y: 100, w: 10, h: 10});
+    const E = newFocusable({id: "E", x: 100, y: 100, w: 10, h: 10});
+
+    const focusableGrid = focusManager.derive2DNavigationArray([A, B, C, D, E]);
+    expect(focusableGrid).toEqual([
+      [A, undefined, B],
+      [undefined, C],
+      [D, undefined, E],
+    ]);
+    focusManager.setContentFocusables(focusableGrid);
+
+    testInput(A, left, A);
+    testInput(A, down, D);
+    testInput(D, up, A);
+    testInput(A, right, B);
+    testInput(B, left, A);
+    testInput(B, down, E);
+    testInput(E, right, D);
+
+    testInput(C, down, D);
+    testInput(C, up, A);
+    testInput(C, left, A);
+    testInput(C, right, B);
+  });
+
+  test("test closest button from center", () => {
+    const A1 = newFocusable({id: "A1", x: 0, y: 0, w: 5, h: 5});
+    const A2 = newFocusable({id: "A2", x: 10, y: 0, w: 5, h: 5});
+    const A3 = newFocusable({id: "A3", x: 0, y: 10, w: 5, h: 5});
+    const A4 = newFocusable({id: "A4", x: 10, y: 10, w: 5, h: 5});
+
+    const B1 = newFocusable({id: "B1", x: 100, y: 0, w: 5, h: 5});
+    const B2 = newFocusable({id: "B2", x: 110, y: 0, w: 5, h: 5});
+    const B3 = newFocusable({id: "B3", x: 100, y: 10, w: 5, h: 5});
+    const B4 = newFocusable({id: "B4", x: 110, y: 10, w: 5, h: 5});
+
+    const C = newFocusable({id: "C", x: 50, y: 50, w: 5, h: 5});
+
+    const D1 = newFocusable({id: "D1", x: 0, y: 100, w: 5, h: 5});
+    const D2 = newFocusable({id: "D2", x: 10, y: 100, w: 5, h: 5});
+    const D3 = newFocusable({id: "D3", x: 0, y: 110, w: 5, h: 5});
+    const D4 = newFocusable({id: "D4", x: 10, y: 110, w: 5, h: 5});
+
+    const E1 = newFocusable({id: "E1", x: 100, y: 100, w: 5, h: 5});
+    const E2 = newFocusable({id: "E2", x: 110, y: 100, w: 5, h: 5});
+    const E3 = newFocusable({id: "E3", x: 100, y: 110, w: 5, h: 5});
+    const E4 = newFocusable({id: "E4", x: 110, y: 110, w: 5, h: 5});
+
+    const focusableGrid = focusManager.derive2DNavigationArray(
+      [A1, A2, A3, A4, B1, B2, B3, B4, C, D1, D2, D3, D4, E1, E2, E3, E4]);
+    expect(focusableGrid).toEqual([
+      [A1,        A2,        undefined, B1, B2],
+      [A3,        A4,        undefined, B3, B4],
+      [undefined, undefined, C],
+      [D1,        D2,        undefined, E1, E2],
+      [D3,        D4,        undefined, E3, E4],
+    ]);
+    focusManager.setContentFocusables(focusableGrid);
+
+    testInput(A1, left, A2);
+    testInput(A2, left, B1);
+    testInput(A2, down, A3);
+    testInput(A3, down, D1);
+    testInput(A4, down, D2);
+
+    testInput(B1, left, B2);
+    testInput(B2, left, B2);
+
+    testInput(D1, up, A3);
+    testInput(D2, up, A4);
+    testInput(D1, left, D2);
+    testInput(D2, left, E1);
+    testInput(D3, left, D4);
+    testInput(D4, left, E3);
+
+    testInput(E1, up, B1);
+    testInput(E1, right, E2);
+    testInput(E1, left, D2);
+    testInput(E2, up, B4);
+    testInput(E2, down, E4);
+    testInput(E3, left, D4);
+
+    testInput(C, down, D2);
+    testInput(C, up, A4);
+    testInput(C, left, A4);
+    testInput(C, right, B3);
+  });
+
+  test("test misaligned button column", () => {
+    const AAA = newFocusable({id: "AAA", x: 10, y: 10, w: 5, h: 10});
+    const BBB = newFocusable({id: "BBB", x: 11, y: 20, w: 5, h: 10});
+    const CCC = newFocusable({id: "CCC", x: 10, y: 30, w: 5, h: 10});
+
+    const focusableGrid = focusManager.derive2DNavigationArray([AAA, BBB, CCC]);
+    expect(focusableGrid).toEqual([
+      [AAA],
+      [undefined, BBB],
+      [CCC],
+    ]);
+    focusManager.setContentFocusables(focusableGrid);
+
+    testInput(AAA, down, CCC);
+    testInput(CCC, up, AAA);
+    testInput(BBB, up, AAA);
+    testInput(BBB, down, CCC);
+    testInput(BBB,left, AAA);
   });
 });

--- a/src/focus_manager/__tests__/derived-focus-navigation-test.js
+++ b/src/focus_manager/__tests__/derived-focus-navigation-test.js
@@ -1,0 +1,57 @@
+import { TXMFocusManager } from "../txm_focus_manager";
+import { Focusable } from "../txm_focusable";
+import { inputActions } from "../txm_input_actions";
+
+describe("derived 2D focus navigation", () => {
+  const fm = new TXMFocusManager();
+
+  function newFocusable({id, x, y, w, h}) {
+    const element = {id, top: y, left: x, bottom: y + h, right: x + w, width: w, height: h};
+    element.getBoundingClientRect = () => element;
+    element.classList = {
+      add: () => {},
+      remove: () => {}
+    };
+    return new Focusable(element);
+  }
+
+  function testInput(currFocus, action, newFocus) {
+    fm.setFocus(currFocus);
+    fm.onInputAction(action);
+    expect(fm.currentFocus).toBe(newFocus);
+  }
+
+  test("test focus grid with overlaps", () => {
+    // NOTE: overlaps are ignored, row/col based solely on top/left position.
+    const f_0_0 = newFocusable({id: "f_0_0", x: 10, y: 10, w: 40, h: 40});
+    const f_0_2 = newFocusable({id: "f_0_2", x: 60, y: 10, w: 40, h: 50});
+    const f_1_2 = newFocusable({id: "f_1_2", x: 60, y: 20, w: 40, h: 40}); // overlaps, still in same row
+    const f_2_4 = newFocusable({id: "f_2_4", x: 140, y: 70, w: 40, h: 40});  // overlaps, still in same row
+    const f_3_0 = newFocusable({id: "f_3_0", x: 10, y: 80, w: 50, h: 40});
+    const f_3_1 = newFocusable({id: "f_3_1", x: 20, y: 80, w: 100, h: 40});
+    const f_3_3 = newFocusable({id: "f_3_3", x: 80, y: 80, w: 40, h: 40});
+    const f_4_5 = newFocusable({id: "f_4_5", x: 200, y: 400, w: 40, h: 40});
+
+    const focusableGrid = fm.derive2DNavigationArray([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
+    expect(focusableGrid).toEqual([
+      [f_0_0,     undefined, f_0_2],
+      [undefined, undefined, f_1_2],
+      [undefined, undefined, undefined, undefined, f_2_4],
+      [f_3_0,     f_3_1,     undefined, f_3_3],
+      [undefined, undefined, undefined, undefined, undefined, f_4_5]
+    ]);
+
+    // Moving along the same row or column takes precedence.
+    testInput(f_0_0, inputActions.moveDown, f_3_1);
+    testInput(f_3_1, inputActions.moveUp, f_0_0);
+    testInput(f_0_0, inputActions.moveRight, f_0_2);
+    testInput(f_0_2, inputActions.moveDown, f_1_2);
+    testInput(f_1_2, inputActions.moveUp, f_0_2);
+    testInput(f_1_2, inputActions.moveDown, f_2_4);
+    testInput(f_2_4, inputActions.moveUp, f_1_2);
+    testInput(f_2_4, inputActions.moveLeft, f_1_2);
+    testInput(f_2_4, inputActions.moveRight, f_4_5);
+    testInput(f_3_1, inputActions.moveRight, f_3_3);
+    testInput(f_3_3, inputActions.moveLeft, f_3_1);
+  });
+});

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -84,7 +84,10 @@ describe("focus navigation", () => {
     const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
     const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
 
-    focusManager.setContentFocusables([A, B]);
+    focusManager.setContentFocusables([
+      A,
+           B
+    ]);
 
     testInput(A, down, B);
     testInput(A, right, B);
@@ -92,6 +95,73 @@ describe("focus navigation", () => {
     testInput(B, left, A);
     testInput(B, right, B);
     testInput(A, up, A);
+  });
+
+  test("test stepping down", () => {
+    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
+    const C = newFocusable({id: "C", x: 90, y: 90, w: 10, h: 10});
+
+    focusManager.setContentFocusables([
+      A,
+         B,
+             C
+    ]);
+
+    testInput(A, down, B);
+    testInput(A, right, B);
+    testInput(B, down, C);
+    testInput(B, right, C);
+    testInput(C, down, C);
+    testInput(C, right, C);
+    testInput(C, up, B);
+    testInput(C, left, B);
+    testInput(B, up, A);
+    testInput(B, left, A);
+  });
+
+  test("test stepping up", () => {
+    const A = newFocusable({id: "A", x: 10, y: 90, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
+    const C = newFocusable({id: "C", x: 90, y: 10, w: 10, h: 10});
+
+    focusManager.setContentFocusables([
+            A,
+         B,
+      C
+    ]);
+
+    testInput(A, up, B);
+    testInput(A, right, B);
+    testInput(B, up, C);
+    testInput(B, right, C);
+    testInput(C, up, C);
+    testInput(C, right, C);
+    testInput(C, down, B);
+    testInput(C, left, B);
+    testInput(B, down, A);
+    testInput(B, left, A);
+  });
+
+  test("test stepping up and down", () => {
+    const A = newFocusable({id: "A", x: 30, y: 10, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 10, y: 30, w: 10, h: 10});
+    const C = newFocusable({id: "C", x: 90, y: 90, w: 10, h: 10});
+
+    focusManager.setContentFocusables([
+         A,
+      B,
+            C
+    ]);
+
+    testInput(A, down, B);
+    testInput(A, right, B);
+    testInput(B, up, A);
+    testInput(B, right, A);
+    testInput(B, down, C);
+    testInput(C, up, A);
+    testInput(C, left, A);
+    testInput(A, left, B);
   });
 
   test("test button square with center", () => {
@@ -121,7 +191,24 @@ describe("focus navigation", () => {
     testInput(C, right, B);
   });
 
-  test("test closest button from center", () => {
+  test("test right to closest row", () => {
+    const A = newFocusable({id: "A", x: 10, y: 10, w: 40, h: 5});
+    const B = newFocusable({id: "B", x: 100, y: 10, w: 40, h: 5});
+    const C = newFocusable({id: "C", x: 10, y: 30, w: 40, h: 5});
+    const D = newFocusable({id: "D", x: 10, y: 30, w: 40, h: 5});
+
+    focusManager.setContentFocusables([
+      A, B,
+      C,
+      D]);
+
+    testInput(A, right, B);
+    testInput(A, down, C);
+    testInput(C, up, A);
+    testInput(C, right, B);
+  });
+
+  test("test closest buttons from center", () => {
     const A1 = newFocusable({id: "A1", x: 0, y: 0, w: 5, h: 5});
     const A2 = newFocusable({id: "A2", x: 10, y: 0, w: 5, h: 5});
     const A3 = newFocusable({id: "A3", x: 0, y: 10, w: 5, h: 5});
@@ -211,7 +298,24 @@ describe("focus navigation", () => {
        DDD]);
 
     testInput(AAA, right, BBB);
-    testInput(AAA, down, CC);
+    testInput(AAA, down, CCC);
+    testInput(CCC, up, AAA);
+    testInput(CCC, right, BBB);
+  });
+
+  test("test right with only vs next column", () => {
+    const AAA = newFocusable({id: "AAA", x: 15, y: 10, w: 40, h: 5});
+    const BBB = newFocusable({id: "BBB", x: 100, y: 10, w: 40, h: 5});
+    const CCC = newFocusable({id: "CCC", x: 10, y: 30, w: 40, h: 5});
+    const DDD = newFocusable({id: "DDD", x: 15, y: 30, w: 40, h: 5});
+
+    focusManager.setContentFocusables([
+      AAA, BBB,
+      CCC,
+      DDD]);
+
+    testInput(AAA, right, BBB);
+    testInput(AAA, down, CCC);
     testInput(CCC, up, AAA);
     testInput(CCC, right, BBB);
   });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -340,12 +340,39 @@ describe("complex navigation tests", () => {
       AAA, BBB
     ]);
 
+    testInput(AAA, left, AAA);
     testInput(AAA, right, BBB);
     testInput(AAA, down, AAA);
     testInput(AAA, up, AAA);
     testInput(BBB, left, AAA);
     testInput(BBB, down, BBB);
     testInput(BBB, up, BBB);
+    testInput(BBB, right, BBB);
+  });
+
+  test("test button overlaps another both right and down", () => {
+    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
+    const BBB = newFocusable("BBB", {x: 80, y: 30, w: 100, h: 100});
+
+    // AAAAAAAAAAA
+    // A         A
+    // A     BBBBBBBBBBBBBB
+    // A     B   A        B
+    // AAAAAABAAAA        B
+    //       B            B
+    //       BBBBBBBBBBBBBB
+    focusManager.setContentFocusables([
+      AAA, BBB
+    ]);
+
+    testInput(AAA, left, AAA);
+    testInput(AAA, right, BBB);
+    testInput(AAA, down, AAA);
+    testInput(AAA, up, AAA);
+    testInput(BBB, left, AAA);
+    testInput(BBB, down, AAA);
+    testInput(BBB, up, BBB);
+    testInput(BBB, right, BBB);
   });
 
   test("test multiple matches in focus column", () => {

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -312,7 +312,7 @@ describe("focus navigation", () => {
     testInput(BBB, left, BBB);
   });
 
-  test("test multiple matches in focus lane", () => {
+  test("test multiple matches in focus column", () => {
     const AAA = newFocusable({id: "AAA", x: 30, y: 10, w: 10, h: 10});
     const BBB = newFocusable({id: "BBB", x: 60, y: 10, w: 10, h: 10});
     const ZZZZZZZZZZZZ = newFocusable({id: "ZZZZZZZZZZZZ", x: 10, y: 30, w: 100, h: 10});
@@ -328,6 +328,9 @@ describe("focus navigation", () => {
     testInput(AAA, down, ZZZZZZZZZZZZ);
     testInput(BBB, down, ZZZZZZZZZZZZ);
 
+    testInput(AAA, left, AAA);
+    testInput(AAA, right, BBB);
+
     testInput(ZZZZZZZZZZZZ, up, AAA);
 
     // align B is exactly with Z's right edge, which makes it a closer match
@@ -339,8 +342,56 @@ describe("focus navigation", () => {
     AAA.element.x = ZZZZZZZZZZZZ.element.x - AAA.element.width + 2; // overlap just a bit with Z's left edge
     testInput(ZZZZZZZZZZZZ, up, AAA);
 
+    // Competing equal distance defer to the left most
+    AAA.element.x = ZZZZZZZZZZZZ.element.x - AAA.element.width;
+    BBB.element.x = ZZZZZZZZZZZZ.element.right - BBB.element.width;
+    testInput(ZZZZZZZZZZZZ, up, AAA);
+
     testInput(ZZZZZZZZZZZZ, down, EEE);
     EEE.element.x += 10; // move a bit more off center
     testInput(ZZZZZZZZZZZZ, down, DDD); // D is now closer to Z's left edge
+  });
+
+  // I.e, like above but rotated.
+  test("test multiple matches in focus row", () => {
+    const A = newFocusable({id: "A", x: 10, y: 30, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 10, y: 60, w: 10, h: 10});
+    const Z = newFocusable({id: "Z", x: 30, y: 10, w: 10, h: 100});
+    const D = newFocusable({id: "D", x: 60, y: 5, w: 10, h: 10});
+    const E = newFocusable({id: "E", x: 60, y: 25, w: 20, h: 10});
+
+    focusManager.setContentFocusables([
+            Z,
+      A, /* Z */ D,
+         /* Z */
+      B, /* Z */ E
+         /* Z */
+    ]);
+
+    testInput(A, right, Z);
+    testInput(B, right, Z);
+
+    testInput(A, up, A);
+    testInput(A, down, B);
+
+    testInput(Z, left, A);
+
+    // align B is exactly with Z's bottom edge, which makes it a closer match
+    const origBy = B.element.y;
+    B.element.y = Z.element.bottom - B.element.height;
+    testInput(Z, left, B);
+
+    B.element.y = origBy;
+    A.element.y = Z.element.y - A.element.height + 2; // overlap just a bit with Z's left edge
+    testInput(Z, left, A);
+
+    // Competing equal distance defer to the left most
+    A.element.y = Z.element.y - A.element.height;
+    B.element.y = Z.element.bottom - B.element.height;
+    testInput(Z, up, A);
+
+    testInput(Z, right, E);
+    E.element.y += 10; // move a bit more off center
+    testInput(Z, right, D); // D is now closer to Z's top edge
   });
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -11,8 +11,9 @@ describe("focus navigation tests", () => {
   const left = inputActions.moveLeft;
   const right = inputActions.moveRight;
 
-  function newFocusable({id, x, y, w, h}) {
-    const element = {id, top: y, left: x, bottom: y + h, right: x + w, width: w, height: h};
+  // Creates a focusable element stub that can be positioned and sized.
+  function newFocusable(id, bounds = {x: 0, y: 0, w: 0, h: 0}) {
+    const element = { id };
     element.classList = {
       add: () => {},
       remove: () => {}
@@ -20,15 +21,18 @@ describe("focus navigation tests", () => {
 
     element.getBoundingClientRect = () => element;
 
-    element.setX = function(x) {
+    element.setBounds = function({x = this.x, y = this.y, w = this.width, h = this.height}) {
       this.x = x;
-      this.right = x + this.width;
+      this.y = y;
+      this.width = w;
+      this.height = h;
+      this.left = x;
+      this.top = y;
+      this.right = x + w;
+      this.bottom = y + h;
     };
 
-    element.setY = function(y) {
-      this.y = y;
-      this.bottom = y + this.height;
-    };
+    element.setBounds(bounds);
 
     return new Focusable(element);
   }
@@ -41,14 +45,14 @@ describe("focus navigation tests", () => {
 
   test("test focus grid with overlaps, gaps", () => {
     // NOTE: overlaps are ignored, row/col based solely on top/left position.
-    const f_0_0 = newFocusable({id: "f_0_0", x: 10, y: 10, w: 40, h: 30});
-    const f_0_2 = newFocusable({id: "f_0_2", x: 60, y: 10, w: 40, h: 30});
-    const f_1_2 = newFocusable({id: "f_1_2", x: 55, y: 40, w: 55, h: 40}); // overlaps
-    const f_2_4 = newFocusable({id: "f_2_4", x: 110, y: 70, w: 40, h: 40});  // overlaps
-    const f_3_0 = newFocusable({id: "f_3_0", x: 10, y: 80, w: 50, h: 40});
-    const f_3_1 = newFocusable({id: "f_3_1", x: 20, y: 80, w: 50, h: 40});
-    const f_3_3 = newFocusable({id: "f_3_3", x: 80, y: 80, w: 40, h: 40});
-    const f_4_5 = newFocusable({id: "f_4_5", x: 200, y: 400, w: 40, h: 40});
+    const f_0_0 = newFocusable("f_0_0", {x: 10, y: 10, w: 40, h: 30});
+    const f_0_2 = newFocusable("f_0_2", {x: 60, y: 10, w: 40, h: 30});
+    const f_1_2 = newFocusable("f_1_2", {x: 55, y: 40, w: 55, h: 40}); // overlaps
+    const f_2_4 = newFocusable("f_2_4", {x: 110, y: 70, w: 40, h: 40});  // overlaps
+    const f_3_0 = newFocusable("f_3_0", {x: 10, y: 80, w: 50, h: 40});
+    const f_3_1 = newFocusable("f_3_1", {x: 20, y: 80, w: 50, h: 40});
+    const f_3_3 = newFocusable("f_3_3", {x: 80, y: 80, w: 40, h: 40});
+    const f_4_5 = newFocusable("f_4_5", {x: 200, y: 400, w: 40, h: 40});
 
     // Note: all focus navigation is done according to the implicit sort into rows by increasing y, each row into columns by increasing x,
     focusManager.setContentFocusables([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
@@ -68,12 +72,12 @@ describe("focus navigation tests", () => {
   });
 
   test("test simple focus grid", () => {
-    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 30, y: 10, w: 10, h: 10});
-    const C = newFocusable({id: "C", x: 50, y: 10, w: 10, h: 10});
-    const D = newFocusable({id: "D", x: 10, y: 30, w: 10, h: 10});
-    const E = newFocusable({id: "E", x: 30, y: 30, w: 10, h: 10});
-    const F = newFocusable({id: "F", x: 50, y: 30, w: 10, h: 10});
+    const A = newFocusable("A", {x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable("B", {x: 30, y: 10, w: 10, h: 10});
+    const C = newFocusable("C", {x: 50, y: 10, w: 10, h: 10});
+    const D = newFocusable("D", {x: 10, y: 30, w: 10, h: 10});
+    const E = newFocusable("E", {x: 30, y: 30, w: 10, h: 10});
+    const F = newFocusable("F", {x: 50, y: 30, w: 10, h: 10});
 
     focusManager.setContentFocusables([
       A, B, C,
@@ -93,8 +97,8 @@ describe("focus navigation tests", () => {
   });
 
   test("test A kitty corner B", () => {
-    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
+    const A = newFocusable("A", {x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable("B", {x: 30, y: 30, w: 10, h: 10});
 
     focusManager.setContentFocusables([
       A,
@@ -110,9 +114,9 @@ describe("focus navigation tests", () => {
   });
 
   test("test stepping down", () => {
-    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
-    const C = newFocusable({id: "C", x: 90, y: 90, w: 10, h: 10});
+    const A = newFocusable("A", {x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable("B", {x: 30, y: 30, w: 10, h: 10});
+    const C = newFocusable("C", {x: 90, y: 90, w: 10, h: 10});
 
     focusManager.setContentFocusables([
       A,
@@ -133,9 +137,9 @@ describe("focus navigation tests", () => {
   });
 
   test("test stepping up", () => {
-    const A = newFocusable({id: "A", x: 10, y: 90, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
-    const C = newFocusable({id: "C", x: 90, y: 10, w: 10, h: 10});
+    const A = newFocusable("A", {x: 10, y: 90, w: 10, h: 10});
+    const B = newFocusable("B", {x: 30, y: 30, w: 10, h: 10});
+    const C = newFocusable("C", {x: 90, y: 10, w: 10, h: 10});
 
     focusManager.setContentFocusables([
             A,
@@ -156,9 +160,9 @@ describe("focus navigation tests", () => {
   });
 
   test("test stepping up and down", () => {
-    const A = newFocusable({id: "A", x: 30, y: 10, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 10, y: 30, w: 10, h: 10});
-    const C = newFocusable({id: "C", x: 90, y: 90, w: 10, h: 10});
+    const A = newFocusable("A", {x: 30, y: 10, w: 10, h: 10});
+    const B = newFocusable("B", {x: 10, y: 30, w: 10, h: 10});
+    const C = newFocusable("C", {x: 90, y: 90, w: 10, h: 10});
 
     focusManager.setContentFocusables([
          A,
@@ -177,11 +181,11 @@ describe("focus navigation tests", () => {
   });
 
   test("test button square with center", () => {
-    const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 100, y: 10, w: 10, h: 10});
-    const C = newFocusable({id: "C", x: 50, y: 50, w: 10, h: 10});
-    const D = newFocusable({id: "D", x: 10, y: 100, w: 10, h: 10});
-    const E = newFocusable({id: "E", x: 100, y: 100, w: 10, h: 10});
+    const A = newFocusable("A", {x: 10, y: 10, w: 10, h: 10});
+    const B = newFocusable("B", {x: 100, y: 10, w: 10, h: 10});
+    const C = newFocusable("C", {x: 50, y: 50, w: 10, h: 10});
+    const D = newFocusable("D", {x: 10, y: 100, w: 10, h: 10});
+    const E = newFocusable("E", {x: 100, y: 100, w: 10, h: 10});
 
     focusManager.setContentFocusables([
       A,  B,
@@ -204,10 +208,10 @@ describe("focus navigation tests", () => {
   });
 
   test("test right to closest row", () => {
-    const A = newFocusable({id: "A", x: 10, y: 10, w: 40, h: 5});
-    const B = newFocusable({id: "B", x: 100, y: 10, w: 40, h: 5});
-    const C = newFocusable({id: "C", x: 10, y: 30, w: 40, h: 5});
-    const D = newFocusable({id: "D", x: 10, y: 90, w: 40, h: 5});
+    const A = newFocusable("A", {x: 10, y: 10, w: 40, h: 5});
+    const B = newFocusable("B", {x: 100, y: 10, w: 40, h: 5});
+    const C = newFocusable("C", {x: 10, y: 30, w: 40, h: 5});
+    const D = newFocusable("D", {x: 10, y: 90, w: 40, h: 5});
 
     focusManager.setContentFocusables([
       A, B,
@@ -222,27 +226,27 @@ describe("focus navigation tests", () => {
   });
 
   test("test closest buttons from center", () => {
-    const A1 = newFocusable({id: "A1", x: 0, y: 0, w: 5, h: 5});
-    const A2 = newFocusable({id: "A2", x: 10, y: 0, w: 5, h: 5});
-    const A3 = newFocusable({id: "A3", x: 0, y: 10, w: 5, h: 5});
-    const A4 = newFocusable({id: "A4", x: 10, y: 10, w: 5, h: 5});
+    const A1 = newFocusable("A1", {x: 0, y: 0, w: 5, h: 5});
+    const A2 = newFocusable("A2", {x: 10, y: 0, w: 5, h: 5});
+    const A3 = newFocusable("A3", {x: 0, y: 10, w: 5, h: 5});
+    const A4 = newFocusable("A4", {x: 10, y: 10, w: 5, h: 5});
 
-    const B1 = newFocusable({id: "B1", x: 100, y: 0, w: 5, h: 5});
-    const B2 = newFocusable({id: "B2", x: 110, y: 0, w: 5, h: 5});
-    const B3 = newFocusable({id: "B3", x: 100, y: 10, w: 5, h: 5});
-    const B4 = newFocusable({id: "B4", x: 110, y: 10, w: 5, h: 5});
+    const B1 = newFocusable("B1", {x: 100, y: 0, w: 5, h: 5});
+    const B2 = newFocusable("B2", {x: 110, y: 0, w: 5, h: 5});
+    const B3 = newFocusable("B3", {x: 100, y: 10, w: 5, h: 5});
+    const B4 = newFocusable("B4", {x: 110, y: 10, w: 5, h: 5});
 
-    const C = newFocusable({id: "C", x: 50, y: 50, w: 5, h: 5});
+    const C = newFocusable("C", {x: 50, y: 50, w: 5, h: 5});
 
-    const D1 = newFocusable({id: "D1", x: 0, y: 100, w: 5, h: 5});
-    const D2 = newFocusable({id: "D2", x: 10, y: 100, w: 5, h: 5});
-    const D3 = newFocusable({id: "D3", x: 0, y: 110, w: 5, h: 5});
-    const D4 = newFocusable({id: "D4", x: 10, y: 110, w: 5, h: 5});
+    const D1 = newFocusable("D1", {x: 0, y: 100, w: 5, h: 5});
+    const D2 = newFocusable("D2", {x: 10, y: 100, w: 5, h: 5});
+    const D3 = newFocusable("D3", {x: 0, y: 110, w: 5, h: 5});
+    const D4 = newFocusable("D4", {x: 10, y: 110, w: 5, h: 5});
 
-    const E1 = newFocusable({id: "E1", x: 100, y: 100, w: 5, h: 5});
-    const E2 = newFocusable({id: "E2", x: 110, y: 100, w: 5, h: 5});
-    const E3 = newFocusable({id: "E3", x: 100, y: 110, w: 5, h: 5});
-    const E4 = newFocusable({id: "E4", x: 110, y: 110, w: 5, h: 5});
+    const E1 = newFocusable("E1", {x: 100, y: 100, w: 5, h: 5});
+    const E2 = newFocusable("E2", {x: 110, y: 100, w: 5, h: 5});
+    const E3 = newFocusable("E3", {x: 100, y: 110, w: 5, h: 5});
+    const E4 = newFocusable("E4", {x: 110, y: 110, w: 5, h: 5});
 
     focusManager.setContentFocusables([
       A1, A2,    B1, B2,
@@ -282,9 +286,9 @@ describe("focus navigation tests", () => {
   });
 
   test("test misaligned button column", () => {
-    const AAA = newFocusable({id: "AAA", x: 10, y: 10, w: 5, h: 10});
-    const BBB = newFocusable({id: "BBB", x: 12, y: 20, w: 5, h: 5});
-    const CCC = newFocusable({id: "CCC", x: 10, y: 30, w: 5, h: 5});
+    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 5, h: 10});
+    const BBB = newFocusable("BBB", {x: 12, y: 20, w: 5, h: 5});
+    const CCC = newFocusable("CCC", {x: 10, y: 30, w: 5, h: 5});
 
     focusManager.setContentFocusables([
       AAA,
@@ -300,8 +304,8 @@ describe("focus navigation tests", () => {
   });
 
   test("test button completely covering another", () => {
-    const AAA = newFocusable({id: "AAA", x: 10, y: 10, w: 100, h: 100});
-    const BBB = newFocusable({id: "BBB", x: 50, y: 50, w: 10, h: 10});
+    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
+    const BBB = newFocusable("BBB", {x: 50, y: 50, w: 10, h: 10});
 
     // AAAAAAAAAAAAAAAA
     // A              A
@@ -325,11 +329,11 @@ describe("focus navigation tests", () => {
   });
 
   test("test multiple matches in focus column", () => {
-    const AAA = newFocusable({id: "AAA", x: 30, y: 10, w: 10, h: 10});
-    const BBB = newFocusable({id: "BBB", x: 80, y: 10, w: 10, h: 10});
-    const ZZZZZZZZZZZZ = newFocusable({id: "ZZZZZZZZZZZZ", x: 10, y: 30, w: 100, h: 10});
-    const DDDD = newFocusable({id: "DDDD", x: 5, y: 60, w: 30, h: 10});
-    const EEE = newFocusable({id: "EEE", x: 50, y: 60, w: 20, h: 10});
+    const AAA = newFocusable("AAA", {x: 30, y: 10, w: 10, h: 10});
+    const BBB = newFocusable("BBB", {x: 80, y: 10, w: 10, h: 10});
+    const ZZZZZZZZZZZZ = newFocusable("ZZZZZZZZZZZZ", {x: 10, y: 30, w: 100, h: 10});
+    const DDDD = newFocusable("DDDD", {x: 5, y: 60, w: 30, h: 10});
+    const EEE = newFocusable("EEE", {x: 50, y: 60, w: 20, h: 10});
 
     focusManager.setContentFocusables([
          AAA, BBB,
@@ -347,34 +351,34 @@ describe("focus navigation tests", () => {
 
     // align B is exactly with Z's right edge, which makes it a closer match
     const origBx = BBB.element.x;
-    BBB.element.setX(ZZZZZZZZZZZZ.element.right - BBB.element.width);
+    BBB.element.setBounds({x: ZZZZZZZZZZZZ.element.right - BBB.element.width});
     testInput(ZZZZZZZZZZZZ, up, BBB);
 
-    BBB.element.setX(origBx);
-    AAA.element.setX(ZZZZZZZZZZZZ.element.x - AAA.element.width + 2); // overlap just a bit with Z's left edge
+    BBB.element.setBounds({x: origBx});
+    AAA.element.setBounds({x: ZZZZZZZZZZZZ.element.x - AAA.element.width + 2}); // overlap just a bit with Z's left edge
     testInput(ZZZZZZZZZZZZ, up, AAA);
 
-    // Competing equal distance defer to the left most
-    AAA.element.setX(ZZZZZZZZZZZZ.element.x - AAA.element.width);
-    BBB.element.setX(ZZZZZZZZZZZZ.element.right - BBB.element.width);
+    // Competing equal distances, defer to the left most
+    AAA.element.setBounds({x: ZZZZZZZZZZZZ.element.x});
+    BBB.element.setBounds({x: ZZZZZZZZZZZZ.element.right - BBB.element.width});
     testInput(ZZZZZZZZZZZZ, up, AAA);
 
     // Make B hang off of Z' right edge a bit, should not be reached moving right.
-    BBB.element.setX(ZZZZZZZZZZZZ.element.right - 2);
+    BBB.element.setBounds({x: ZZZZZZZZZZZZ.element.right - 2});
     testInput(ZZZZZZZZZZZZ, right, ZZZZZZZZZZZZ);
 
     testInput(ZZZZZZZZZZZZ, down, EEE);
-    EEE.element.setX(EEE.element.x + 10); // move a bit more off center
+    EEE.element.setBounds({x: EEE.element.x + 10}); // move a bit more off center
     testInput(ZZZZZZZZZZZZ, down, DDDD); // D is now closer to Z's left edge
   });
 
   // I.e, like above but rotated.
   test("test multiple matches in focus row", () => {
-    const A = newFocusable({id: "A", x: 10, y: 30, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 10, y: 80, w: 10, h: 10});
-    const Z = newFocusable({id: "Z", x: 30, y: 10, w: 10, h: 100});
-    const D = newFocusable({id: "D", x: 60, y: 5, w: 10, h: 30});
-    const E = newFocusable({id: "E", x: 60, y: 50, w: 10, h: 20});
+    const A = newFocusable("A", {x: 10, y: 30, w: 10, h: 10});
+    const B = newFocusable("B", {x: 10, y: 80, w: 10, h: 10});
+    const Z = newFocusable("Z", {x: 30, y: 10, w: 10, h: 100});
+    const D = newFocusable("D", {x: 60, y: 5, w: 10, h: 30});
+    const E = newFocusable("E", {x: 60, y: 50, w: 10, h: 20});
 
     focusManager.setContentFocusables([
             Z,
@@ -394,24 +398,24 @@ describe("focus navigation tests", () => {
 
     // align B is exactly with Z's bottom edge, which makes it a closer match
     const origBy = B.element.y;
-    B.element.setY(Z.element.bottom - B.element.height);
+    B.element.setBounds({y: Z.element.bottom - B.element.height});
     testInput(Z, left, B);
 
-    B.element.setY(origBy);
-    A.element.setY(Z.element.y - A.element.height + 2); // overlap just a bit with Z's left edge
+    B.element.setBounds({y: origBy});
+    A.element.setBounds({y: Z.element.y - A.element.height + 2}); // overlap just a bit with Z's left edge
     testInput(Z, left, A);
 
-    // Competing equal distance defer to the left most
-    A.element.setY(Z.element.y - A.element.height);
-    B.element.setY(Z.element.bottom - B.element.height);
-    testInput(Z, up, A);
+    // Competing equal distance defer to the top most
+    A.element.setBounds({y: Z.element.y});
+    B.element.setBounds({y: Z.element.bottom - B.element.height});
+    testInput(Z, left, A);
 
     // Make B hang off of Z' bottom edge a bit, should not be reached moving down.
-    B.element.setY(Z.element.bottom - 2);
+    B.element.setBounds({y: Z.element.bottom - 2});
     testInput(Z, down, Z);
 
     testInput(Z, right, E);
-    E.element.setY(E.element.y + 10); // move a bit more off center
+    E.element.setBounds({y: E.element.y + 10}); // move a bit more off center
     testInput(Z, right, D); // D is now closer to Z's top edge
   });
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -48,9 +48,9 @@ describe("complex navigation tests", () => {
     const f_0_2 = newFocusable("f_0_2", {x: 60, y: 10, w: 40, h: 30});
     const f_1_2 = newFocusable("f_1_2", {x: 55, y: 40, w: 55, h: 40}); // overlaps
     const f_2_4 = newFocusable("f_2_4", {x: 110, y: 70, w: 40, h: 40});  // overlaps
-    const f_3_0 = newFocusable("f_3_0", {x: 10, y: 80, w: 50, h: 40});
-    const f_3_1 = newFocusable("f_3_1", {x: 20, y: 80, w: 50, h: 40});
-    const f_3_3 = newFocusable("f_3_3", {x: 80, y: 80, w: 40, h: 40});
+    const f_3_0 = newFocusable("f_3_0", {x: 10, y: 115, w: 50, h: 40});
+    const f_3_1 = newFocusable("f_3_1", {x: 60, y: 115, w: 50, h: 40});
+    const f_3_3 = newFocusable("f_3_3", {x: 115, y: 115, w: 40, h: 40});
     const f_4_5 = newFocusable("f_4_5", {x: 200, y: 400, w: 40, h: 40});
 
     // Note: all focus navigation is done by finding the visually closest match, first in the implied focus row/col
@@ -63,7 +63,7 @@ describe("complex navigation tests", () => {
     testInput(f_0_0, right, f_0_2);
     testInput(f_0_2, down, f_1_2);
     testInput(f_1_2, up, f_0_2);
-    testInput(f_1_2, down, f_3_0);
+    testInput(f_1_2, down, f_3_1);
     testInput(f_2_4, left, f_1_2);
     testInput(f_2_4, up, f_0_2);
     testInput(f_2_4, right, f_4_5);

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -2,7 +2,7 @@ import { TXMFocusManager } from "../txm_focus_manager";
 import { Focusable } from "../txm_focusable";
 import { inputActions } from "../txm_input_actions";
 
-describe("focus navigation", () => {
+describe("focus navigation tests", () => {
 
   const focusManager = new TXMFocusManager();
 

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -192,8 +192,8 @@ describe("focus navigation", () => {
 
     testInput(AAA, right, AAA);
     testInput(AAA, down, BBB);
-    testInput(CCC, up, AAA);
-    testInput(BBB, up, CCC);
+    testInput(CCC, up, BBB);
+    testInput(BBB, up, AAA);
     testInput(BBB, down, CCC);
     testInput(BBB,left, BBB);
   });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -322,10 +322,10 @@ describe("complex navigation tests", () => {
     testInput(AAA, left, AAA);
 
     // Should not be possible to get to BBB, but if it happened, perhaps with autofocus:
-    testInput(BBB, right, BBB);
-    testInput(BBB, down, BBB);
-    testInput(BBB, up, BBB);
-    testInput(BBB, left, BBB);
+    testInput(BBB, right, AAA);
+    testInput(BBB, down, AAA);
+    testInput(BBB, up, AAA);
+    testInput(BBB, left, AAA);
   });
 
   test("test button overlaps another", () => {

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -225,6 +225,58 @@ describe("complex navigation tests", () => {
     testInput(B, down, C);
   });
 
+  test("test row along then column up", () => {
+    const A = newFocusable("A", {x: 90, y: 10, w: 10, h: 10});
+    const B = newFocusable("B", {x: 90, y: 30, w: 10, h: 10});
+    const C = newFocusable("C", {x: 90, y: 60, w: 10, h: 10});
+    const D = newFocusable("D", {x: 10, y: 90, w: 10, h: 10});
+    const E = newFocusable("E", {x: 30, y: 90, w: 10, h: 10});
+    const F = newFocusable("F", {x: 60, y: 90, w: 10, h: 10});
+    const G = newFocusable("G", {x: 90, y: 90, w: 10, h: 10});
+
+    focusManager.setContentFocusables([
+               A,
+               B,
+               C,
+      D, E, F, G
+    ]);
+
+    testInput(A, right, A);
+    testInput(A, left, F);
+    testInput(A, down, B);
+    testInput(A, up, A);
+
+    testInput(B, right, B);
+    testInput(B, left, F);
+    testInput(B, down, C);
+    testInput(B, up, A);
+
+    testInput(C, right, C);
+    testInput(C, left, F);
+    testInput(C, down, G);
+    testInput(C, up, B);
+
+    testInput(D, left, D);
+    testInput(D, right, E);
+    testInput(D, down, D);
+    testInput(D, up, C);
+
+    testInput(E, left, D);
+    testInput(E, right, F);
+    testInput(E, down, E);
+    testInput(E, up, C);
+
+    testInput(F, left, E);
+    testInput(F, right, G);
+    testInput(F, down, F);
+    testInput(F, up, C);
+
+    testInput(G, left, F);
+    testInput(G, right, G);
+    testInput(G, down, G);
+    testInput(G, up, C);
+  });
+
   test("test closest buttons from center", () => {
     const A1 = newFocusable("A1", {x: 0, y: 0, w: 5, h: 5});
     const A2 = newFocusable("A2", {x: 10, y: 0, w: 5, h: 5});

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -13,11 +13,23 @@ describe("focus navigation", () => {
 
   function newFocusable({id, x, y, w, h}) {
     const element = {id, top: y, left: x, bottom: y + h, right: x + w, width: w, height: h};
-    element.getBoundingClientRect = () => element;
     element.classList = {
       add: () => {},
       remove: () => {}
     };
+
+    element.getBoundingClientRect = () => element;
+
+    element.setX = function(x) {
+      this.x = x;
+      this.right = x + this.width;
+    };
+
+    element.setY = function(y) {
+      this.y = y;
+      this.bottom = y + this.height;
+    };
+
     return new Focusable(element);
   }
 
@@ -314,15 +326,15 @@ describe("focus navigation", () => {
 
   test("test multiple matches in focus column", () => {
     const AAA = newFocusable({id: "AAA", x: 30, y: 10, w: 10, h: 10});
-    const BBB = newFocusable({id: "BBB", x: 60, y: 10, w: 10, h: 10});
+    const BBB = newFocusable({id: "BBB", x: 80, y: 10, w: 10, h: 10});
     const ZZZZZZZZZZZZ = newFocusable({id: "ZZZZZZZZZZZZ", x: 10, y: 30, w: 100, h: 10});
-    const DDD = newFocusable({id: "DDD", x: 5, y: 60, w: 10, h: 10});
-    const EEE = newFocusable({id: "EEE", x: 25, y: 60, w: 20, h: 10});
+    const DDDD = newFocusable({id: "DDDD", x: 5, y: 60, w: 30, h: 10});
+    const EEE = newFocusable({id: "EEE", x: 45, y: 60, w: 20, h: 10});
 
     focusManager.setContentFocusables([
          AAA, BBB,
        ZZZZZZZZZZZZ,
-      DDD, EEE
+      DDDD, EEE
     ]);
 
     testInput(AAA, down, ZZZZZZZZZZZZ);
@@ -335,34 +347,34 @@ describe("focus navigation", () => {
 
     // align B is exactly with Z's right edge, which makes it a closer match
     const origBx = BBB.element.x;
-    BBB.element.x = ZZZZZZZZZZZZ.element.right - BBB.element.width;
+    BBB.element.setX(ZZZZZZZZZZZZ.element.right - BBB.element.width);
     testInput(ZZZZZZZZZZZZ, up, BBB);
 
-    BBB.element.x = origBx;
-    AAA.element.x = ZZZZZZZZZZZZ.element.x - AAA.element.width + 2; // overlap just a bit with Z's left edge
+    BBB.element.setX(origBx);
+    AAA.element.setX(ZZZZZZZZZZZZ.element.x - AAA.element.width + 2); // overlap just a bit with Z's left edge
     testInput(ZZZZZZZZZZZZ, up, AAA);
 
     // Competing equal distance defer to the left most
-    AAA.element.x = ZZZZZZZZZZZZ.element.x - AAA.element.width;
-    BBB.element.x = ZZZZZZZZZZZZ.element.right - BBB.element.width;
+    AAA.element.setX(ZZZZZZZZZZZZ.element.x - AAA.element.width);
+    BBB.element.setX(ZZZZZZZZZZZZ.element.right - BBB.element.width);
     testInput(ZZZZZZZZZZZZ, up, AAA);
 
     // Make B hang off of Z' right edge a bit, should not be reached moving right.
-    BBB.element.x = ZZZZZZZZZZZZ.element.right - 2;
+    BBB.element.setX(ZZZZZZZZZZZZ.element.right - 2);
     testInput(ZZZZZZZZZZZZ, right, ZZZZZZZZZZZZ);
 
     testInput(ZZZZZZZZZZZZ, down, EEE);
-    EEE.element.x += 10; // move a bit more off center
-    testInput(ZZZZZZZZZZZZ, down, DDD); // D is now closer to Z's left edge
+    EEE.element.setX(EEE.element.x + 10); // move a bit more off center
+    testInput(ZZZZZZZZZZZZ, down, DDDD); // D is now closer to Z's left edge
   });
 
   // I.e, like above but rotated.
   test("test multiple matches in focus row", () => {
     const A = newFocusable({id: "A", x: 10, y: 30, w: 10, h: 10});
-    const B = newFocusable({id: "B", x: 10, y: 60, w: 10, h: 10});
+    const B = newFocusable({id: "B", x: 10, y: 80, w: 10, h: 10});
     const Z = newFocusable({id: "Z", x: 30, y: 10, w: 10, h: 100});
-    const D = newFocusable({id: "D", x: 60, y: 5, w: 10, h: 10});
-    const E = newFocusable({id: "E", x: 60, y: 25, w: 20, h: 10});
+    const D = newFocusable({id: "D", x: 60, y: 5, w: 10, h: 30});
+    const E = newFocusable({id: "E", x: 60, y: 45, w: 20, h: 10});
 
     focusManager.setContentFocusables([
             Z,
@@ -382,24 +394,24 @@ describe("focus navigation", () => {
 
     // align B is exactly with Z's bottom edge, which makes it a closer match
     const origBy = B.element.y;
-    B.element.y = Z.element.bottom - B.element.height;
+    B.element.setY(Z.element.bottom - B.element.height);
     testInput(Z, left, B);
 
-    B.element.y = origBy;
-    A.element.y = Z.element.y - A.element.height + 2; // overlap just a bit with Z's left edge
+    B.element.setY(origBy);
+    A.element.setY(Z.element.y - A.element.height + 2); // overlap just a bit with Z's left edge
     testInput(Z, left, A);
 
     // Competing equal distance defer to the left most
-    A.element.y = Z.element.y - A.element.height;
-    B.element.y = Z.element.bottom - B.element.height;
+    A.element.setY(Z.element.y - A.element.height);
+    B.element.setY(Z.element.bottom - B.element.height);
     testInput(Z, up, A);
 
     // Make B hang off of Z' bottom edge a bit, should not be reached moving down.
-    BBB.element.y = ZZZZZZZZZZZZ.element.bottom - 2;
+    BBB.element.setY(ZZZZZZZZZZZZ.element.bottom - 2);
     testInput(ZZZZZZZZZZZZ, down, ZZZZZZZZZZZZ);
 
     testInput(Z, right, E);
-    E.element.y += 10; // move a bit more off center
+    E.element.setY(E.element.y + 10); // move a bit more off center
     testInput(Z, right, D); // D is now closer to Z's top edge
   });
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -375,28 +375,7 @@ describe("complex navigation tests", () => {
     testInput(AAA, right, BBB);
 
     testInput(ZZZZZZZZZZZZ, up, AAA);
-
-    // align B is exactly with Z's right edge, which makes it a closer match
-    const origBx = BBB.element.x;
-    BBB.element.setBounds({x: ZZZZZZZZZZZZ.element.right - BBB.element.width});
-    testInput(ZZZZZZZZZZZZ, up, BBB);
-
-    BBB.element.setBounds({x: origBx});
-    AAA.element.setBounds({x: ZZZZZZZZZZZZ.element.x - AAA.element.width + 2}); // overlap just a bit with Z's left edge
-    testInput(ZZZZZZZZZZZZ, up, AAA);
-
-    // Competing equal distances, defer to the left most
-    AAA.element.setBounds({x: ZZZZZZZZZZZZ.element.x});
-    BBB.element.setBounds({x: ZZZZZZZZZZZZ.element.right - BBB.element.width});
-    testInput(ZZZZZZZZZZZZ, up, AAA);
-
-    // Make B hang off of Z' right edge a bit, should not be reached moving right.
-    BBB.element.setBounds({x: ZZZZZZZZZZZZ.element.right - 2});
-    testInput(ZZZZZZZZZZZZ, right, ZZZZZZZZZZZZ);
-
-    testInput(ZZZZZZZZZZZZ, down, EEE);
-    EEE.element.setBounds({x: EEE.element.x + 10}); // move a bit more off center
-    testInput(ZZZZZZZZZZZZ, down, DDDD); // D is now closer to Z's left edge
+    testInput(ZZZZZZZZZZZZ, down, DDDD);
   });
 
   // I.e, like above but rotated.
@@ -422,28 +401,8 @@ describe("complex navigation tests", () => {
     testInput(A, down, B);
 
     testInput(Z, left, A);
-
-    // align B is exactly with Z's bottom edge, which makes it a closer match
-    const origBy = B.element.y;
-    B.element.setBounds({y: Z.element.bottom - B.element.height});
-    testInput(Z, left, B);
-
-    B.element.setBounds({y: origBy});
-    A.element.setBounds({y: Z.element.y - A.element.height + 2}); // overlap just a bit with Z's left edge
-    testInput(Z, left, A);
-
-    // Competing equal distance defer to the top most
-    A.element.setBounds({y: Z.element.y});
-    B.element.setBounds({y: Z.element.bottom - B.element.height});
-    testInput(Z, left, A);
-
-    // Make B hang off of Z' bottom edge a bit, should not be reached moving down.
-    B.element.setBounds({y: Z.element.bottom - 2});
     testInput(Z, down, Z);
-
-    testInput(Z, right, E);
-    E.element.setBounds({y: E.element.y + 10}); // move a bit more off center
-    testInput(Z, right, D); // D is now closer to Z's top edge
+    testInput(Z, right, D);
   });
 
   test("test button completely covering another", () => {

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -368,14 +368,22 @@ describe("complex navigation tests", () => {
       DDDD, EEE
     ]);
 
-    testInput(AAA, down, ZZZZZZZZZZZZ);
-    testInput(BBB, down, ZZZZZZZZZZZZ);
-
     testInput(AAA, left, AAA);
     testInput(AAA, right, BBB);
 
+    testInput(AAA, down, ZZZZZZZZZZZZ);
+    testInput(BBB, down, ZZZZZZZZZZZZ);
+
     testInput(ZZZZZZZZZZZZ, up, AAA);
     testInput(ZZZZZZZZZZZZ, down, DDDD);
+    testInput(ZZZZZZZZZZZZ, left, ZZZZZZZZZZZZ);
+    testInput(ZZZZZZZZZZZZ, right, ZZZZZZZZZZZZ);
+
+    // Move A and D outside of focus lane.
+    AAA.element.setBounds({x: ZZZZZZZZZZZZ.element.x - AAA.element.width});
+    DDDD.element.setBounds({x: ZZZZZZZZZZZZ.element.x - DDDD.element.width});
+    testInput(ZZZZZZZZZZZZ, up, BBB);
+    testInput(ZZZZZZZZZZZZ, down, EEE);
   });
 
   // I.e, like above but rotated.
@@ -401,8 +409,15 @@ describe("complex navigation tests", () => {
     testInput(A, down, B);
 
     testInput(Z, left, A);
-    testInput(Z, down, Z);
     testInput(Z, right, D);
+    testInput(Z, up, Z);
+    testInput(Z, down, Z);
+
+    // Move A and D outside of focus lane.
+    A.element.setBounds({y: Z.element.y - A.element.height});
+    D.element.setBounds({y: Z.element.y - D.element.height});
+    testInput(Z, left, B);
+    testInput(Z, right, E);
   });
 
   test("test button completely covering another", () => {

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -137,9 +137,9 @@ describe("complex navigation tests", () => {
   });
 
   test("test stepping up", () => {
-    const A = newFocusable("A", {x: 10, y: 90, w: 10, h: 10});
+    const A = newFocusable("A", {x: 90, y: 10, w: 10, h: 10});
     const B = newFocusable("B", {x: 30, y: 30, w: 10, h: 10});
-    const C = newFocusable("C", {x: 90, y: 10, w: 10, h: 10});
+    const C = newFocusable("C", {x: 10, y: 90, w: 10, h: 10});
 
     focusManager.setContentFocusables([
             A,
@@ -147,16 +147,16 @@ describe("complex navigation tests", () => {
       C
     ]);
 
-    testInput(A, up, B);
-    testInput(A, right, B);
-    testInput(B, up, C);
-    testInput(B, right, C);
-    testInput(C, up, C);
-    testInput(C, right, C);
-    testInput(C, down, B);
-    testInput(C, left, B);
-    testInput(B, down, A);
-    testInput(B, left, A);
+    testInput(A, up, A);
+    testInput(A, down, B);
+    testInput(B, up, A);
+    testInput(B, right, A);
+    testInput(B, down, C);
+    testInput(B, left, C);
+    testInput(C, up, B);
+    testInput(C, right, B);
+    testInput(C, down, C);
+    testInput(C, left, C);
   });
 
   test("test stepping up and down", () => {

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -29,12 +29,12 @@ describe("focus navigation", () => {
 
   test("test focus grid with overlaps, gaps", () => {
     // NOTE: overlaps are ignored, row/col based solely on top/left position.
-    const f_0_0 = newFocusable({id: "f_0_0", x: 10, y: 10, w: 40, h: 40});
-    const f_0_2 = newFocusable({id: "f_0_2", x: 60, y: 10, w: 40, h: 50});
-    const f_1_2 = newFocusable({id: "f_1_2", x: 60, y: 20, w: 40, h: 40}); // overlaps, still in same row
-    const f_2_4 = newFocusable({id: "f_2_4", x: 140, y: 70, w: 40, h: 40});  // overlaps, still in same row
+    const f_0_0 = newFocusable({id: "f_0_0", x: 10, y: 10, w: 40, h: 30});
+    const f_0_2 = newFocusable({id: "f_0_2", x: 60, y: 10, w: 40, h: 30});
+    const f_1_2 = newFocusable({id: "f_1_2", x: 55, y: 40, w: 55, h: 40}); // overlaps
+    const f_2_4 = newFocusable({id: "f_2_4", x: 110, y: 70, w: 40, h: 40});  // overlaps
     const f_3_0 = newFocusable({id: "f_3_0", x: 10, y: 80, w: 50, h: 40});
-    const f_3_1 = newFocusable({id: "f_3_1", x: 20, y: 80, w: 100, h: 40});
+    const f_3_1 = newFocusable({id: "f_3_1", x: 20, y: 80, w: 50, h: 40});
     const f_3_3 = newFocusable({id: "f_3_3", x: 80, y: 80, w: 40, h: 40});
     const f_4_5 = newFocusable({id: "f_4_5", x: 200, y: 400, w: 40, h: 40});
 
@@ -42,14 +42,14 @@ describe("focus navigation", () => {
     focusManager.setContentFocusables([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
 
     // Moving along the same row or column takes precedence.
-    testInput(f_0_0, down, f_3_1);
-    testInput(f_3_1, up, f_0_0);
+    testInput(f_0_0, down, f_3_0);
+    testInput(f_3_0, up, f_1_2);
     testInput(f_0_0, right, f_0_2);
     testInput(f_0_2, down, f_1_2);
     testInput(f_1_2, up, f_0_2);
-    testInput(f_1_2, down, f_2_4);
-    testInput(f_2_4, up, f_1_2);
+    testInput(f_1_2, down, f_3_0);
     testInput(f_2_4, left, f_1_2);
+    testInput(f_2_4, up, f_0_2);
     testInput(f_2_4, right, f_4_5);
     testInput(f_3_1, right, f_3_3);
     testInput(f_3_3, left, f_3_1);

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -198,4 +198,21 @@ describe("focus navigation", () => {
     testInput(BBB, down, CCC);
     testInput(BBB,left, BBB);
   });
+
+  test("test right with overlapping vs next column", () => {
+    const AAA = newFocusable({id: "AAA", x: 15, y: 10, w: 40, h: 5});
+    const BBB = newFocusable({id: "BBB", x: 100, y: 10, w: 40, h: 5});
+    const CCC = newFocusable({id: "CCC", x: 10, y: 30, w: 40, h: 5});
+    const DDD = newFocusable({id: "DDD", x: 15, y: 30, w: 40, h: 5});
+
+    focusManager.setContentFocusables([
+       AAA, BBB,
+      CCC,
+       DDD]);
+
+    testInput(AAA, right, BBB);
+    testInput(AAA, down, CC);
+    testInput(CCC, up, AAA);
+    testInput(CCC, right, BBB);
+  });
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -2,7 +2,7 @@ import { TXMFocusManager } from "../txm_focus_manager";
 import { Focusable } from "../txm_focusable";
 import { inputActions } from "../txm_input_actions";
 
-describe("derived 2D focus navigation", () => {
+describe("focus navigation", () => {
 
   const focusManager = new TXMFocusManager();
 
@@ -38,16 +38,8 @@ describe("derived 2D focus navigation", () => {
     const f_3_3 = newFocusable({id: "f_3_3", x: 80, y: 80, w: 40, h: 40});
     const f_4_5 = newFocusable({id: "f_4_5", x: 200, y: 400, w: 40, h: 40});
 
-    // Note: all focusables get sorted into rows by increasing y, each row into columns by increasing x.
-    const focusableGrid = focusManager.derive2DNavigationArray([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
-    expect(focusableGrid).toEqual([
-      [f_0_0,     undefined, f_0_2],
-      [undefined, undefined, f_1_2],
-      [undefined, undefined, undefined, undefined, f_2_4],
-      [f_3_0,     f_3_1,     undefined, f_3_3],
-      [undefined, undefined, undefined, undefined, undefined, f_4_5]
-    ]);
-    focusManager.setContentFocusables(focusableGrid);
+    // Note: all focus navigation is done according to the implicit sort into rows by increasing y, each row into columns by increasing x,
+    focusManager.setContentFocusables([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
 
     // Moving along the same row or column takes precedence.
     testInput(f_0_0, down, f_3_1);
@@ -71,12 +63,10 @@ describe("derived 2D focus navigation", () => {
     const E = newFocusable({id: "E", x: 30, y: 30, w: 10, h: 10});
     const F = newFocusable({id: "F", x: 50, y: 30, w: 10, h: 10});
 
-    const focusableGrid = focusManager.derive2DNavigationArray([A, B, C, D, E, F]);
-    expect(focusableGrid).toEqual([
-      [A, B, C],
-      [D, E, F],
+    focusManager.setContentFocusables([
+      A, B, C,
+      D, E, F,
     ]);
-    focusManager.setContentFocusables(focusableGrid);
 
     testInput(A, down, D);
     testInput(D, up, A);
@@ -94,12 +84,7 @@ describe("derived 2D focus navigation", () => {
     const A = newFocusable({id: "A", x: 10, y: 10, w: 10, h: 10});
     const B = newFocusable({id: "B", x: 30, y: 30, w: 10, h: 10});
 
-    const focusableGrid = focusManager.derive2DNavigationArray([A, B]);
-    expect(focusableGrid).toEqual([
-      [A],
-      [undefined, B],
-    ]);
-    focusManager.setContentFocusables(focusableGrid);
+    focusManager.setContentFocusables([A, B]);
 
     testInput(A, down, B);
     testInput(A, right, B);
@@ -116,13 +101,11 @@ describe("derived 2D focus navigation", () => {
     const D = newFocusable({id: "D", x: 10, y: 100, w: 10, h: 10});
     const E = newFocusable({id: "E", x: 100, y: 100, w: 10, h: 10});
 
-    const focusableGrid = focusManager.derive2DNavigationArray([A, B, C, D, E]);
-    expect(focusableGrid).toEqual([
-      [A, undefined, B],
-      [undefined, C],
-      [D, undefined, E],
+    focusManager.setContentFocusables([
+      A,  B,
+        C,
+      D,  E
     ]);
-    focusManager.setContentFocusables(focusableGrid);
 
     testInput(A, left, A);
     testInput(A, down, D);
@@ -161,16 +144,12 @@ describe("derived 2D focus navigation", () => {
     const E3 = newFocusable({id: "E3", x: 100, y: 110, w: 5, h: 5});
     const E4 = newFocusable({id: "E4", x: 110, y: 110, w: 5, h: 5});
 
-    const focusableGrid = focusManager.derive2DNavigationArray(
-      [A1, A2, A3, A4, B1, B2, B3, B4, C, D1, D2, D3, D4, E1, E2, E3, E4]);
-    expect(focusableGrid).toEqual([
-      [A1,        A2,        undefined, B1, B2],
-      [A3,        A4,        undefined, B3, B4],
-      [undefined, undefined, C],
-      [D1,        D2,        undefined, E1, E2],
-      [D3,        D4,        undefined, E3, E4],
-    ]);
-    focusManager.setContentFocusables(focusableGrid);
+    focusManager.setContentFocusables([
+      A1, A2,    B1, B2,
+      A3, A4,    B3, B4,
+              C,
+      D1, D2,    E1, E2,
+      D3, D4,    E3, E4]);
 
     testInput(A1, left, A2);
     testInput(A2, left, B1);
@@ -203,21 +182,19 @@ describe("derived 2D focus navigation", () => {
 
   test("test misaligned button column", () => {
     const AAA = newFocusable({id: "AAA", x: 10, y: 10, w: 5, h: 10});
-    const BBB = newFocusable({id: "BBB", x: 11, y: 20, w: 5, h: 10});
-    const CCC = newFocusable({id: "CCC", x: 10, y: 30, w: 5, h: 10});
+    const BBB = newFocusable({id: "BBB", x: 12, y: 20, w: 5, h: 5});
+    const CCC = newFocusable({id: "CCC", x: 10, y: 30, w: 5, h: 5});
 
-    const focusableGrid = focusManager.derive2DNavigationArray([AAA, BBB, CCC]);
-    expect(focusableGrid).toEqual([
-      [AAA],
-      [undefined, BBB],
-      [CCC],
-    ]);
-    focusManager.setContentFocusables(focusableGrid);
+    focusManager.setContentFocusables([
+      AAA,
+       BBB,
+      CCC]);
 
-    testInput(AAA, down, CCC);
+    testInput(AAA, right, AAA);
+    testInput(AAA, down, BBB);
     testInput(CCC, up, AAA);
-    testInput(BBB, up, AAA);
+    testInput(BBB, up, CCC);
     testInput(BBB, down, CCC);
-    testInput(BBB,left, AAA);
+    testInput(BBB,left, BBB);
   });
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -303,78 +303,6 @@ describe("complex navigation tests", () => {
     testInput(BBB,left, BBB);
   });
 
-  test("test button completely covering another", () => {
-    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
-    const BBB = newFocusable("BBB", {x: 50, y: 50, w: 10, h: 10});
-
-    // AAAAAAAAAAAAAAAA
-    // A              A
-    // A     BBBB     A
-    // A              A
-    // AAAAAAAAAAAAAAAA
-    focusManager.setContentFocusables([
-       AAA, BBB
-    ]);
-
-    testInput(AAA, right, AAA);
-    testInput(AAA, down, AAA);
-    testInput(AAA, up, AAA);
-    testInput(AAA, left, AAA);
-
-    // Should not be possible to get to BBB, but if it happened, perhaps with autofocus:
-    testInput(BBB, right, AAA);
-    testInput(BBB, down, AAA);
-    testInput(BBB, up, AAA);
-    testInput(BBB, left, AAA);
-  });
-
-  test("test button overlaps another", () => {
-    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
-    const BBB = newFocusable("BBB", {x: 80, y: 10, w: 100, h: 100});
-
-    // AAAAAABBBBBBBBBB
-    // A     B  A     B
-    // A     B  A     B
-    // AAAAAABBBBBBBBBB
-    focusManager.setContentFocusables([
-      AAA, BBB
-    ]);
-
-    testInput(AAA, left, AAA);
-    testInput(AAA, right, BBB);
-    testInput(AAA, down, AAA);
-    testInput(AAA, up, AAA);
-    testInput(BBB, left, AAA);
-    testInput(BBB, down, BBB);
-    testInput(BBB, up, BBB);
-    testInput(BBB, right, BBB);
-  });
-
-  test("test button overlaps another both right and down", () => {
-    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
-    const BBB = newFocusable("BBB", {x: 80, y: 30, w: 100, h: 100});
-
-    // AAAAAAAAAAA
-    // A         A
-    // A     BBBBBBBBBBBBBB
-    // A     B   A        B
-    // AAAAAABAAAA        B
-    //       B            B
-    //       BBBBBBBBBBBBBB
-    focusManager.setContentFocusables([
-      AAA, BBB
-    ]);
-
-    testInput(AAA, left, AAA);
-    testInput(AAA, right, BBB);
-    testInput(AAA, down, AAA);
-    testInput(AAA, up, AAA);
-    testInput(BBB, left, AAA);
-    testInput(BBB, down, AAA);
-    testInput(BBB, up, BBB);
-    testInput(BBB, right, BBB);
-  });
-
   test("test multiple matches in focus column", () => {
     const AAA = newFocusable("AAA", {x: 30, y: 10, w: 10, h: 10});
     const BBB = newFocusable("BBB", {x: 80, y: 10, w: 10, h: 10});
@@ -464,5 +392,102 @@ describe("complex navigation tests", () => {
     testInput(Z, right, E);
     E.element.setBounds({y: E.element.y + 10}); // move a bit more off center
     testInput(Z, right, D); // D is now closer to Z's top edge
+  });
+
+  test("test button completely covering another", () => {
+    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
+    const BBB = newFocusable("BBB", {x: 50, y: 50, w: 10, h: 10});
+
+    // AAAAAAAAAAAAAAAA
+    // A              A
+    // A     BBBB     A
+    // A              A
+    // AAAAAAAAAAAAAAAA
+    focusManager.setContentFocusables([
+      AAA, BBB
+    ]);
+
+    testInput(AAA, right, AAA);
+    testInput(AAA, down, AAA);
+    testInput(AAA, up, AAA);
+    testInput(AAA, left, AAA);
+
+    // Should not be possible to get to BBB, but if it happened, perhaps with autofocus:
+    testInput(BBB, right, AAA);
+    testInput(BBB, down, AAA);
+    testInput(BBB, up, AAA);
+    testInput(BBB, left, AAA);
+  });
+
+  test("test button overlaps another", () => {
+    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
+    const BBB = newFocusable("BBB", {x: 80, y: 10, w: 100, h: 100});
+
+    // AAAAAABBBBBBBBBB
+    // A     B  A     B
+    // A     B  A     B
+    // AAAAAABBBBBBBBBB
+    focusManager.setContentFocusables([
+      AAA, BBB
+    ]);
+
+    testInput(AAA, left, AAA);
+    testInput(AAA, right, BBB);
+    testInput(AAA, down, AAA);
+    testInput(AAA, up, AAA);
+    testInput(BBB, left, AAA);
+    testInput(BBB, down, BBB);
+    testInput(BBB, up, BBB);
+    testInput(BBB, right, BBB);
+  });
+
+  test("test button overlaps another both right and down", () => {
+    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
+    const BBB = newFocusable("BBB", {x: 80, y: 30, w: 100, h: 100});
+
+    // AAAAAAAAAAA
+    // A         A
+    // A     BBBBBBBBBBBBBB
+    // A     B   A        B
+    // AAAAAABAAAA        B
+    //       B            B
+    //       BBBBBBBBBBBBBB
+    focusManager.setContentFocusables([
+      AAA, BBB
+    ]);
+
+    testInput(AAA, left, AAA);
+    testInput(AAA, right, BBB);
+    testInput(AAA, down, BBB);
+    testInput(AAA, up, AAA);
+    testInput(BBB, left, AAA);
+    testInput(BBB, down, BBB);
+    testInput(BBB, up, AAA);
+    testInput(BBB, right, BBB);
+  });
+
+  test("test button overlaps another both right and up", () => {
+    const AAA = newFocusable("AAA", {x: 80, y: 10, w: 100, h: 100});
+    const BBB = newFocusable("BBB", {x: 10, y: 30, w: 100, h: 100});
+
+    //       AAAAAAAAAAAAAA
+    //       A            A
+    // BBBBBBABBBB        A
+    // B     A   B        A
+    // B     AAAAAAAAAAAAAA
+    // B         B
+    // BBBBBBBBBBB
+    focusManager.setContentFocusables([
+      AAA, BBB
+    ]);
+
+    testInput(AAA, left, BBB);
+    testInput(AAA, right, AAA);
+    testInput(AAA, down, BBB);
+    testInput(AAA, up, AAA);
+    testInput(BBB, left, BBB);
+    testInput(BBB, right, AAA);
+    testInput(BBB, down, BBB);
+    testInput(BBB, up, AAA);
   });
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -155,11 +155,11 @@ describe("focus navigation", () => {
     ]);
 
     testInput(A, down, B);
-    testInput(A, right, B);
+    testInput(A, left, B);
     testInput(B, up, A);
     testInput(B, right, A);
     testInput(B, down, C);
-    testInput(C, up, A);
+    testInput(C, up, B);
     testInput(C, left, A);
     testInput(A, left, B);
   });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -2,7 +2,7 @@ import { TXMFocusManager } from "../txm_focus_manager";
 import { Focusable } from "../txm_focusable";
 import { inputActions } from "../txm_input_actions";
 
-describe("focus navigation tests", () => {
+describe("complex navigation tests", () => {
 
   const focusManager = new TXMFocusManager();
 

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -347,6 +347,10 @@ describe("focus navigation", () => {
     BBB.element.x = ZZZZZZZZZZZZ.element.right - BBB.element.width;
     testInput(ZZZZZZZZZZZZ, up, AAA);
 
+    // Make B hang off of Z' right edge a bit, should not be reached moving right.
+    BBB.element.x = ZZZZZZZZZZZZ.element.right - 2;
+    testInput(ZZZZZZZZZZZZ, right, ZZZZZZZZZZZZ);
+
     testInput(ZZZZZZZZZZZZ, down, EEE);
     EEE.element.x += 10; // move a bit more off center
     testInput(ZZZZZZZZZZZZ, down, DDD); // D is now closer to Z's left edge
@@ -389,6 +393,10 @@ describe("focus navigation", () => {
     A.element.y = Z.element.y - A.element.height;
     B.element.y = Z.element.bottom - B.element.height;
     testInput(Z, up, A);
+
+    // Make B hang off of Z' bottom edge a bit, should not be reached moving down.
+    BBB.element.y = ZZZZZZZZZZZZ.element.bottom - 2;
+    testInput(ZZZZZZZZZZZZ, down, ZZZZZZZZZZZZ);
 
     testInput(Z, right, E);
     E.element.y += 10; // move a bit more off center

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -44,7 +44,6 @@ describe("complex navigation tests", () => {
   }
 
   test("test focus grid with overlaps, gaps", () => {
-    // NOTE: overlaps are ignored, row/col based solely on top/left position.
     const f_0_0 = newFocusable("f_0_0", {x: 10, y: 10, w: 40, h: 30});
     const f_0_2 = newFocusable("f_0_2", {x: 60, y: 10, w: 40, h: 30});
     const f_1_2 = newFocusable("f_1_2", {x: 55, y: 40, w: 55, h: 40}); // overlaps
@@ -54,7 +53,8 @@ describe("complex navigation tests", () => {
     const f_3_3 = newFocusable("f_3_3", {x: 80, y: 80, w: 40, h: 40});
     const f_4_5 = newFocusable("f_4_5", {x: 200, y: 400, w: 40, h: 40});
 
-    // Note: all focus navigation is done according to the implicit sort into rows by increasing y, each row into columns by increasing x,
+    // Note: all focus navigation is done by finding the visually closest match, first in the implied focus row/col
+    // falling back to the next leftmost/topmost item in the following row/col.
     focusManager.setContentFocusables([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
 
     // Moving along the same row or column takes precedence.

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -21,7 +21,7 @@ describe("focus navigation tests", () => {
 
     element.getBoundingClientRect = () => element;
 
-    element.setBounds = function({x = this.x, y = this.y, w = this.width, h = this.height}) {
+    element.setBounds = function({x = this.x || 0, y = this.y || 0, w = this.width || 0, h = this.height || 0}) {
       this.x = x;
       this.y = y;
       this.width = w;

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -151,23 +151,24 @@ describe("focus navigation", () => {
       D1, D2,    E1, E2,
       D3, D4,    E3, E4]);
 
-    testInput(A1, left, A2);
-    testInput(A2, left, B1);
-    testInput(A2, down, A3);
+    testInput(A1, right, A2);
+    testInput(A2, right, B1);
+    testInput(A1, down, A3);
+    testInput(A2, down, A4);
     testInput(A3, down, D1);
     testInput(A4, down, D2);
 
-    testInput(B1, left, B2);
-    testInput(B2, left, B2);
+    testInput(B1, right, B2);
+    testInput(B2, right, B2);
 
     testInput(D1, up, A3);
     testInput(D2, up, A4);
-    testInput(D1, left, D2);
-    testInput(D2, left, E1);
-    testInput(D3, left, D4);
-    testInput(D4, left, E3);
+    testInput(D1, right, D2);
+    testInput(D2, right, E1);
+    testInput(D3, right, D4);
+    testInput(D4, right, E3);
 
-    testInput(E1, up, B1);
+    testInput(E1, up, B3);
     testInput(E1, right, E2);
     testInput(E1, left, D2);
     testInput(E2, up, B4);

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -328,6 +328,26 @@ describe("complex navigation tests", () => {
     testInput(BBB, left, BBB);
   });
 
+  test("test button overlaps another", () => {
+    const AAA = newFocusable("AAA", {x: 10, y: 10, w: 100, h: 100});
+    const BBB = newFocusable("BBB", {x: 80, y: 10, w: 100, h: 100});
+
+    // AAAAAABBBBBBBBBB
+    // A     B  A     B
+    // A     B  A     B
+    // AAAAAABBBBBBBBBB
+    focusManager.setContentFocusables([
+      AAA, BBB
+    ]);
+
+    testInput(AAA, right, BBB);
+    testInput(AAA, down, AAA);
+    testInput(AAA, up, AAA);
+    testInput(BBB, left, AAA);
+    testInput(BBB, down, BBB);
+    testInput(BBB, up, BBB);
+  });
+
   test("test multiple matches in focus column", () => {
     const AAA = newFocusable("AAA", {x: 30, y: 10, w: 10, h: 10});
     const BBB = newFocusable("BBB", {x: 80, y: 10, w: 10, h: 10});

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -329,7 +329,7 @@ describe("focus navigation", () => {
     const BBB = newFocusable({id: "BBB", x: 80, y: 10, w: 10, h: 10});
     const ZZZZZZZZZZZZ = newFocusable({id: "ZZZZZZZZZZZZ", x: 10, y: 30, w: 100, h: 10});
     const DDDD = newFocusable({id: "DDDD", x: 5, y: 60, w: 30, h: 10});
-    const EEE = newFocusable({id: "EEE", x: 45, y: 60, w: 20, h: 10});
+    const EEE = newFocusable({id: "EEE", x: 50, y: 60, w: 20, h: 10});
 
     focusManager.setContentFocusables([
          AAA, BBB,
@@ -374,7 +374,7 @@ describe("focus navigation", () => {
     const B = newFocusable({id: "B", x: 10, y: 80, w: 10, h: 10});
     const Z = newFocusable({id: "Z", x: 30, y: 10, w: 10, h: 100});
     const D = newFocusable({id: "D", x: 60, y: 5, w: 10, h: 30});
-    const E = newFocusable({id: "E", x: 60, y: 45, w: 20, h: 10});
+    const E = newFocusable({id: "E", x: 60, y: 50, w: 10, h: 20});
 
     focusManager.setContentFocusables([
             Z,
@@ -407,8 +407,8 @@ describe("focus navigation", () => {
     testInput(Z, up, A);
 
     // Make B hang off of Z' bottom edge a bit, should not be reached moving down.
-    BBB.element.setY(ZZZZZZZZZZZZ.element.bottom - 2);
-    testInput(ZZZZZZZZZZZZ, down, ZZZZZZZZZZZZ);
+    B.element.setY(Z.element.bottom - 2);
+    testInput(Z, down, Z);
 
     testInput(Z, right, E);
     E.element.setY(E.element.y + 10); // move a bit more off center

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -63,7 +63,7 @@ describe("complex navigation tests", () => {
     testInput(f_0_0, right, f_0_2);
     testInput(f_0_2, down, f_1_2);
     testInput(f_1_2, up, f_0_2);
-    testInput(f_1_2, down, f_3_1);
+    testInput(f_1_2, down, f_3_0);
     testInput(f_2_4, left, f_1_2);
     testInput(f_2_4, up, f_0_2);
     testInput(f_2_4, right, f_4_5);

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -89,7 +89,7 @@ describe("focus navigation", () => {
     testInput(A, down, B);
     testInput(A, right, B);
     testInput(B, up, A);
-    testInput(B, right, A);
+    testInput(B, left, A);
     testInput(B, right, B);
     testInput(A, up, A);
   });
@@ -113,7 +113,7 @@ describe("focus navigation", () => {
     testInput(A, right, B);
     testInput(B, left, A);
     testInput(B, down, E);
-    testInput(E, right, D);
+    testInput(E, left, D);
 
     testInput(C, down, D);
     testInput(C, up, A);

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -506,81 +506,59 @@ describe("TXMFocusManager", () => {
             fm.setTopChromeFocusables([topChrome[1], topChrome[2], topChrome[3]]);
             fm.setBottomChromeFocusables([bottomChrome[1], bottomChrome[2]]);
             fm.setContentFocusables([
-                [focuses[1], focuses[2], focuses[3]],
+                focuses[1], focuses[2], focuses[3],
                 focuses[4]
             ]);
 
-            test("default initial focus is first content item", () => {
-                expect(fm.currentFocus).toBe(focuses[1]);
-            });
+            // default initial focus is first content item"
+            expect(fm.currentFocus).toBe(focuses[1]);
 
             test("default focus on movement is in content area", () => {
-                fm.setFocus(undefined);
-                fm.navigateToNewFocus(inputActions.moveLeft);
-                expect(fm.currentFocus).toBe(focuses[1]);
+                testInput(fm, undefined, inputActions.moveLeft, focuses[1]);
             });
 
             test("no loss of focus moving left off the left edge of top chrome", () => {
-                fm.setFocus(topChrome[1]);
-                fm.navigateToNewFocus(inputActions.moveLeft);
-                expect(fm.currentFocus).toBe(topChrome[1]);
+                testInput(fm, topChrome[1], inputActions.moveLeft, topChrome[1]);
             });
 
             test("move right along top chrome", () => {
-                fm.navigateToNewFocus(inputActions.moveRight);
-                expect(fm.currentFocus).toBe(topChrome[2]);
-
-                fm.navigateToNewFocus(inputActions.moveRight);
-                expect(fm.currentFocus).toBe(topChrome[3]);
+                testInput(fm, topChrome[1], inputActions.moveRight, topChrome[2]);
+                testInput(fm, topChrome[2], inputActions.moveRight, topChrome[3]);
             });
 
             test("no loss of focus moving right or up off the right edge of top chrome", () => {
-                fm.navigateToNewFocus(inputActions.moveRight);
-                expect(fm.currentFocus).toBe(topChrome[3]);
-
-                fm.navigateToNewFocus(inputActions.moveUp);
-                expect(fm.currentFocus).toBe(topChrome[3]);
+                testInput(fm, topChrome[3], inputActions.moveRight, topChrome[3]);
+                testInput(fm, topChrome[3], inputActions.moveUp, topChrome[3]);
             });
 
             test("moving down from top chrome goes to first content focus", () => {
-                // establish last saved top focus for later
-                fm.navigateToNewFocus(inputActions.moveLeft);
-                expect(fm.currentFocus).toBe(topChrome[2]);
-
-                fm.navigateToNewFocus(inputActions.moveDown);
-                expect(fm.currentFocus).toBe(focuses[1]);
+                testInput(fm, topChrome[3], inputActions.moveLeft, topChrome[2]);
+                testInput(fm, topChrome[2], inputActions.moveDown, focuses[1]);
             });
 
             test("moving down within content stays within content focusables", () => {
-                fm.navigateToNewFocus(inputActions.moveDown);
-                expect(fm.currentFocus).toBe(focuses[4]);
-
-                fm.navigateToNewFocus(inputActions.moveUp);
-                expect(fm.currentFocus).toBe(focuses[1]);
-
-                fm.navigateToNewFocus(inputActions.moveDown);
-                expect(fm.currentFocus).toBe(focuses[4]);
+                testInput(fm, focuses[1], inputActions.moveDown, focuses[4]);
+                testInput(fm, focuses[4], inputActions.moveDown, focuses[1]);
+                testInput(fm, focuses[1], inputActions.moveDown, focuses[4]);
             });
 
             test("moving down from last content row moves down to first bottom chrome", () => {
-                fm.navigateToNewFocus(inputActions.moveDown);
-                expect(fm.currentFocus).toBe(bottomChrome[1]);
+                testInput(fm, focuses[4], inputActions.moveDown, bottomChrome[1]);
             });
 
             test("no loss of focus moving down from last bottom chrome row", () => {
-                fm.navigateToNewFocus(inputActions.moveDown);
-                expect(fm.currentFocus).toBe(bottomChrome[1]);
+                testInput(fm, bottomChrome[1], inputActions.moveDown, bottomChrome[1]);
             });
 
             test("moving within bottom chrome works", () => {
-                fm.navigateToNewFocus(inputActions.moveRight);
-                expect(fm.currentFocus).toBe(bottomChrome[2]);
+                testInput(fm, bottomChrome[1], inputActions.moveRight, bottomChrome[2]);
             });
 
             test("moving up from bottom chrome moves to last saved content focus", () => {
-                fm.setContentFocusables([focuses[1], focuses[2], focuses[3]]);
-                fm.setFocus(focuses[2]);
-                fm.setFocus(bottomChrome[2]);
+                testInput(fm, focuses[2], inputActions.moveDown, bottomChrome[2]);
+
+                fm.navigateToNewFocus(inputActions.moveUp);
+                expect(fm.currentFocus).toBe(focuses[2]);
 
                 fm.navigateToNewFocus(inputActions.moveUp);
                 expect(fm.currentFocus).toBe(focuses[2]);

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -405,7 +405,7 @@ describe("TXMFocusManager", () => {
             expect(fm.currentFocus).toBe(focuses[3]);
 
             fm.setContentFocusables([focuses[2], focuses[1]]);
-            expect(fm.currentFocus).toBe(focuses[1]); // defaults to first visual focus
+            expect(fm.currentFocus).toBe(focuses[1]); // defaults to top left visual focus
 
             fm.setContentFocusables([focuses[2], focuses[1]], focuses[2]);
             expect(fm.currentFocus).toBe(focuses[2]);

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -624,8 +624,8 @@ describe("TXMFocusManager", () => {
         describe("derived 2D focus navigation", () => {
             const fm = new TXMFocusManager();
 
-            function newStub({id, top, left, bottom, right}) {
-                const element = {id, top, left, bottom, right, width: right - left, height: bottom - top};
+            function newStub({id, x, y, w, h}) {
+                const element = {id, top: y, left: x, bottom: y + h, right: x + w, width: w, height: h};
                 element.getBoundingClientRect = () => element;
                 element.classList = {
                     add: () => {},
@@ -642,14 +642,14 @@ describe("TXMFocusManager", () => {
 
             test("test focus grid with overlaps", () => {
                 // NOTE: overlaps are ignored, row/col based solely on top/left position.
-                const f_0_0 = newStub({id: "f_0_0", top: 10, left: 10, bottom: 50, right: 50});
-                const f_0_2 = newStub({id: "f_0_2", top: 10, left: 60, bottom: 60, right: 100});
-                const f_1_2 = newStub({id: "f_1_2", top: 20, left: 60, bottom: 60, right: 100}); // overlaps, still in same row
-                const f_2_4 = newStub({id: "f_2_4", top: 70, left: 140, bottom: 110, right: 180});  // overlaps, still in same row
-                const f_3_0 = newStub({id: "f_3_0", top: 80, left: 10, bottom: 120, right: 60});
-                const f_3_1 = newStub({id: "f_3_1", top: 80, left: 20, bottom: 120, right: 120});
-                const f_3_3 = newStub({id: "f_3_3", top: 80, left: 80, bottom: 120, right: 120});
-                const f_4_5 = newStub({id: "f_4_5", top: 400, left: 200, bottom: 440, right: 240});
+                const f_0_0 = newStub({id: "f_0_0", x: 10, y: 10, w: 40, h: 40});
+                const f_0_2 = newStub({id: "f_0_2", x: 60, y: 10, w: 40, h: 50});
+                const f_1_2 = newStub({id: "f_1_2", x: 60, y: 20, w: 40, h: 40}); // overlaps, still in same row
+                const f_2_4 = newStub({id: "f_2_4", x: 140, y: 70, w: 40, h: 40});  // overlaps, still in same row
+                const f_3_0 = newStub({id: "f_3_0", x: 10, y: 80, w: 50, h: 40});
+                const f_3_1 = newStub({id: "f_3_1", x: 20, y: 80, w: 100, h: 40});
+                const f_3_3 = newStub({id: "f_3_3", x: 80, y: 80, w: 40, h: 40});
+                const f_4_5 = newStub({id: "f_4_5", x: 200, y: 400, w: 40, h: 40});
 
                 const focusableGrid = fm.derive2DNavigationArray([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
                 expect(focusableGrid).toEqual([

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -620,59 +620,5 @@ describe("TXMFocusManager", () => {
                 expect(fm.currentFocus).toBe(focuses[2]);
             });
         });
-
-        describe("derived 2D focus navigation", () => {
-            const fm = new TXMFocusManager();
-
-            function newStub({id, x, y, w, h}) {
-                const element = {id, top: y, left: x, bottom: y + h, right: x + w, width: w, height: h};
-                element.getBoundingClientRect = () => element;
-                element.classList = {
-                    add: () => {},
-                    remove: () => {}
-                };
-                return new Focusable(element);
-            }
-
-            function testNavigation(currFocus, action, newFocus) {
-                fm.setFocus(currFocus);
-                fm.onInputAction(action);
-                expect(fm.currentFocus).toBe(newFocus);
-            }
-
-            test("test focus grid with overlaps", () => {
-                // NOTE: overlaps are ignored, row/col based solely on top/left position.
-                const f_0_0 = newStub({id: "f_0_0", x: 10, y: 10, w: 40, h: 40});
-                const f_0_2 = newStub({id: "f_0_2", x: 60, y: 10, w: 40, h: 50});
-                const f_1_2 = newStub({id: "f_1_2", x: 60, y: 20, w: 40, h: 40}); // overlaps, still in same row
-                const f_2_4 = newStub({id: "f_2_4", x: 140, y: 70, w: 40, h: 40});  // overlaps, still in same row
-                const f_3_0 = newStub({id: "f_3_0", x: 10, y: 80, w: 50, h: 40});
-                const f_3_1 = newStub({id: "f_3_1", x: 20, y: 80, w: 100, h: 40});
-                const f_3_3 = newStub({id: "f_3_3", x: 80, y: 80, w: 40, h: 40});
-                const f_4_5 = newStub({id: "f_4_5", x: 200, y: 400, w: 40, h: 40});
-
-                const focusableGrid = fm.derive2DNavigationArray([f_4_5, f_0_0, f_3_1, f_2_4, f_3_3, f_1_2, f_0_2, f_3_0]);
-                expect(focusableGrid).toEqual([
-                    [f_0_0,     undefined, f_0_2],
-                    [undefined, undefined, f_1_2],
-                    [undefined, undefined, undefined, undefined, f_2_4],
-                    [f_3_0,     f_3_1,     undefined, f_3_3],
-                    [undefined, undefined, undefined, undefined, undefined, f_4_5]
-                ]);
-
-                // Moving along the same row or column takes precedence.
-                testNavigation(f_0_0, inputActions.moveDown, f_3_1);
-                testNavigation(f_3_1, inputActions.moveUp, f_0_0);
-                testNavigation(f_0_0, inputActions.moveRight, f_0_2);
-                testNavigation(f_0_2, inputActions.moveDown, f_1_2);
-                testNavigation(f_1_2, inputActions.moveUp, f_0_2);
-                testNavigation(f_1_2, inputActions.moveDown, f_2_4);
-                testNavigation(f_2_4, inputActions.moveUp, f_1_2);
-                testNavigation(f_2_4, inputActions.moveLeft, f_1_2);
-                testNavigation(f_2_4, inputActions.moveRight, f_4_5);
-                testNavigation(f_3_1, inputActions.moveRight, f_3_3);
-                testNavigation(f_3_3, inputActions.moveLeft, f_3_1);
-            });
-        });
     });
 });

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -405,6 +405,9 @@ describe("TXMFocusManager", () => {
             expect(fm.currentFocus).toBe(focuses[3]);
 
             fm.setContentFocusables([focuses[2], focuses[1]]);
+            expect(fm.currentFocus).toBe(focuses[1]); // defaults to first visual focus
+
+            fm.setContentFocusables([focuses[2], focuses[1]], focuses[2]);
             expect(fm.currentFocus).toBe(focuses[2]);
 
             fm.setTopChromeFocusables([focuses[1], focuses[2]]);

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -405,7 +405,7 @@ describe("TXMFocusManager", () => {
             expect(fm.currentFocus).toBe(focuses[3]);
 
             fm.setContentFocusables([focuses[2], focuses[1]]);
-            expect(fm.currentFocus).toBe(focuses[1]); // defaults to top left visual focus
+            expect(fm.currentFocus).toBe(focuses[1]); // defaults to top left visual focus regardless of input order
 
             fm.setContentFocusables([focuses[2], focuses[1]], focuses[2]);
             expect(fm.currentFocus).toBe(focuses[2]);

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -392,9 +392,9 @@ describe("TXMFocusManager", () => {
 
         describe("simple left/right focus navigation", () => {
             const fm = new TXMFocusManager();
+            fm.setContentFocusables([focuses[1], focuses[2], focuses[3]]);
 
             test("No loss of focus moving down off row", () => {
-                fm.setContentFocusables([focuses[1], focuses[2], focuses[3]]);
                 fm.onInputAction(inputActions.moveDown);
                 expect(fm.currentFocus).toBe(focuses[1]);
             });

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -656,8 +656,8 @@ export class TXMFocusManager {
                 var newFocusDistance;
                 const focusIntersection = getBoundsIntersection(newBounds, focusBounds);
                 if (fromFocus !== newF && focusIntersection && !equalBounds(focusIntersection, newBounds)) {
-                    // However, if two focusables actually visually intersect but not completely covers,
-                    // we assume the develop knows this and that things look visually ok. E.g. this happens
+                    // However, if two focusables actually visually intersect but not completely cover the other,
+                    // we assume the developer knows this and that things look visually ok. E.g. this happens
                     // with production choice cards, where the Yes/No buttons technically have overlapping
                     // images, although the core visible content does not overlap.
                     //

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -652,7 +652,7 @@ export class TXMFocusManager {
                 if (mustBeInVisualLane && !overlapsFocusLane(newLane)) return;
 
                 const newLaneCenter = getLaneCenter(newLane);
-                const newLaneDistance = newLaneCenter - focusLaneCenter;
+                const newLaneDistance = Math.abs(newLaneCenter - focusLaneCenter);
 
                 var useNewFocus = false;
                 if (currResult) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -678,8 +678,7 @@ export class TXMFocusManager {
                     // with production choice cards, where the Yes/No buttons technically have overlapping
                     // images, although the core visible content does not overlap.
                     //
-                    // In this case, we measure between the two item center points instead of the leading edge
-                    // that is beyond the current focus.
+                    // In this case, we measure from the opposite edge of the new focus item.
                     newBeyondDistance = getFarEdgeDistance(newBounds);
                     if (newBeyondDistance <= 0) {
                         // new focus' far edge must be beyond the current focus's far edge

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -704,12 +704,12 @@ export class TXMFocusManager {
         traverse(array);
         return result;
 
-        function traverse(currArray) {
-            if (!currArray) return;
-            if (Array.isArray(currArray)) {
-                currArray.forEach(traverse);
+        function traverse(value) {
+            if (!value) return;
+            if (Array.isArray(value)) {
+                value.forEach(traverse);
             } else {
-                result.push(currArray); // found an element
+                result.push(value); // found an element
             }
         }
     }

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -598,7 +598,8 @@ export class TXMFocusManager {
     }
 
     hasFocusable(focusable) {
-        return this.isInTopChrome(focusable) || this.isInContent(focusable) || this.isInBottomChrome(focusable);
+        return focusable &&
+          (this.isInTopChrome(focusable) || this.isInContent(focusable) || this.isInBottomChrome(focusable));
     }
 
     findNextFocus(fromFocus, forAction, inFocusables) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -605,26 +605,31 @@ export class TXMFocusManager {
         var getLaneRange;
         var getDistanceBeyondFocus;
         var getBoundsCenter;
+        var getCenterDistance;
         switch (forAction) {
             case inputActions.moveRight:
                 getLaneRange = bounds => { return {start: bounds.top, end: bounds.bottom} };
                 getDistanceBeyondFocus = newBounds => newBounds.left - focusBounds.right;
                 getBoundsCenter = bounds => getCenter(bounds.left, bounds.right);
+                getCenterDistance = (newCenter, focusCenter) => newCenter - focusCenter;
                 break;
             case inputActions.moveLeft:
                 getLaneRange = bounds => { return {start: bounds.top, end: bounds.bottom} };
                 getDistanceBeyondFocus = newBounds => focusBounds.left - newBounds.right;
                 getBoundsCenter = bounds => getCenter(bounds.left, bounds.right);
+                getCenterDistance = (newCenter, focusCenter) => focusCenter - newCenter;
                 break;
             case inputActions.moveDown:
                 getLaneRange = bounds => { return {start: bounds.left, end: bounds.right} };
                 getDistanceBeyondFocus = newBounds => newBounds.top - focusBounds.bottom;
                 getBoundsCenter = bounds => getCenter(bounds.top, bounds.bottom);
+                getCenterDistance = (newCenter, focusCenter) => newCenter - focusCenter;
                 break;
             case inputActions.moveUp:
                 getLaneRange = bounds => { return {start: bounds.left, end: bounds.right} };
                 getDistanceBeyondFocus = newBounds => focusBounds.top - newBounds.bottom;
                 getBoundsCenter = bounds => getCenter(bounds.top, bounds.bottom);
+                getCenterDistance = (newCenter, focusCenter) => focusCenter - newCenter;
                 break;
             default:
                 // Not a movement action.
@@ -662,9 +667,12 @@ export class TXMFocusManager {
                     //
                     // In this case, we measure between the two item center points instead of the leading edge that is beyond
                     // the current focus.
-                    newFocusDistance = getBoundsCenter(newBounds) - getBoundsCenter(focusBounds);
+                    newFocusDistance = getCenterDistance(getBoundsCenter(newBounds), getBoundsCenter(focusBounds));
+                    if (newFocusDistance <= 0) return; // center must be beyond the current focus
+
+                } else if (newFocusDistance < 0) {
+                    return; // new focus edge must be adjacent or beyond
                 }
-                if (newFocusDistance < 0) return;
 
                 const newLane = getLaneRange(newBounds);
                 if (mustBeInVisualLane && !overlapsLane(newLane)) return;

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -649,7 +649,7 @@ export class TXMFocusManager {
                 if (newDistance < 0) return;
 
                 const newLane = getLaneRange(newBounds);
-                if (mustBeInVisualLane && !overlapsFocusLane(newLane)) return;
+                if (mustBeInVisualLane && !overlapsLane(newLane)) return;
 
                 const newLaneCenter = getLaneCenter(newLane);
                 const newLaneDistance = Math.abs(newLaneCenter - focusLaneCenter);
@@ -681,9 +681,9 @@ export class TXMFocusManager {
               || {top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0};
         }
 
-        function overlapsFocusLane(newRange) {
-            if (focusLane.start <= newRange.start && newRange.start <= focusLane.end) return true;
-            if (newRange.start <= focusLane.start && focusLane.start <= newRange.end) return true;
+        function overlapsLane(newLane) {
+            if (focusLane.start <= newLane.start && newLane.start <= focusLane.end) return true;
+            if (newLane.start <= focusLane.start && focusLane.start <= newLane.end) return true;
             return false;
         }
     }

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -625,7 +625,9 @@ export class TXMFocusManager {
                 // Not a movement action.
                 return;
         }
+
         const focusLane = getLaneRange(focusBounds);
+        const focusLaneCenter = getLaneCenter(focusLane);
 
         // First try to find the best match in the same visual row or column.
         var result = findBestResult(true);
@@ -638,6 +640,7 @@ export class TXMFocusManager {
         function findBestResult(mustBeInVisualLane) {
             var currResult;
             var currDistance;
+            var currLaneDistance;
             inFocusables.forEach(newF => {
                 const newBounds = getBoundsOf(newF);
 
@@ -648,19 +651,29 @@ export class TXMFocusManager {
                 const newLane = getLaneRange(newBounds);
                 if (mustBeInVisualLane && !overlapsFocusLane(newLane)) return;
 
+                const newLaneCenter = getLaneCenter(newLane);
+                const newLaneDistance = newLaneCenter - focusLaneCenter;
+
+                var useNewFocus = false;
                 if (currResult) {
-                    if (newDistance < currDistance) {
+                    if (newDistance < currDistance || newDistance == currDistance && newLaneDistance < currLaneDistance) {
                         // This focusable is closer to the current focus.
-                        currResult = newF;
-                        currDistance = newDistance;
+                        useNewFocus = true;
                     }
                 } else {
-                    // First possible result.
+                    useNewFocus = true; // first possible result
+                }
+                if (useNewFocus) {
                     currResult = newF;
                     currDistance = newDistance;
+                    currLaneDistance = newLaneDistance;
                 }
             });
             return currResult;
+        }
+
+        function getLaneCenter(laneRange) {
+            return (laneRange.end - laneRange.start) / 2;
         }
 
         function getBoundsOf(focusable) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -642,6 +642,8 @@ export class TXMFocusManager {
             var currFocusDistance;
             var currLaneDistance;
             inFocusables.forEach(newF => {
+                if (!newF) return;
+
                 const newBounds = getBoundsOf(newF);
 
                 const newFocusDistance = getDistanceBeyondFocus(newBounds);

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -645,6 +645,7 @@ export class TXMFocusManager {
                 if (!newF) return;
 
                 const newBounds = getBoundsOf(newF);
+                if (newBounds.width <= 0 || newBounds.height <= 0) return;
 
                 const newFocusDistance = getDistanceBeyondFocus(newBounds);
                 // only look at focusables that are actually visually beyond the current focus edge

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -635,7 +635,7 @@ export class TXMFocusManager {
 
         // First try to find the best match in the same visual row or column long the direction of movement,
         // i.e. anything overlapping the same focus lane.
-        var result = findNextClosestFocus((newRange, currState) => {
+        var result = findNextClosestFocus(newRange => {
             const overlapRange = {
                 start: Math.max(newRange.start, focusLane.start),
                 end: Math.min(newRange.end, focusLane.end)
@@ -650,7 +650,7 @@ export class TXMFocusManager {
 
         if (!result) {
             // Finally look for the remaining outside items closest to the focus lane.
-            result = findNextClosestFocus((newRange, currState) => {
+            result = findNextClosestFocus(newRange => {
                 const newDistance = (newRange.end <= focusLane.end)
                     ? focusLane.end - newRange.end // i.e. to the left/top of the focus lane
                     :  newRange.start - focusLane.start; // to the right/bottom of the focus lane

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -644,8 +644,8 @@ export class TXMFocusManager {
                 // only look at focusables that are actually visually beyond the current focus edge
                 if (newDistance < 0) return;
 
-                const newRange = getLaneRange(newBounds);
-                if (mustBeInVisualLane && !overlapsFocusLane(newRange)) return;
+                const newLane = getLaneRange(newBounds);
+                if (mustBeInVisualLane && !overlapsFocusLane(newLane)) return;
 
                 if (currResult) {
                     if (newDistance < currDistance) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -665,6 +665,10 @@ export class TXMFocusManager {
             return currResult;
         }
 
+        function getLaneCenter(laneRange) {
+            return (laneRange.end - laneRange.start) / 2;
+        }
+
         function getDistanceFromFocusLane(laneRange) {
             // Returns the smallest distance from the start vs end vs center points.
             const laneCenter = getLaneCenter(laneRange);

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -509,7 +509,7 @@ export class TXMFocusManager {
      */
     setTopChromeFocusables(focusables) {
         this._lastTopFocus = undefined;
-        this._topChromeFocusables = this.flattenArray(focusables);
+        this._topChromeFocusables = this.sortVisually(this.flattenArray(focusables));
     }
 
     /**
@@ -518,7 +518,7 @@ export class TXMFocusManager {
      */
     setBottomChromeFocusables(focusables) {
         this._lastBottomFocus = undefined;
-        this._bottomChromeFocusables = this.flattenArray(focusables);
+        this._bottomChromeFocusables = this.sortVisually(this.flattenArray(focusables));
     }
 
     /**
@@ -536,7 +536,7 @@ export class TXMFocusManager {
         const isInBottomChrome = this.isInBottomChrome(current);
         const resetFocus = !current || !isInTopChrome && !isInBottomChrome;
 
-        this._contentFocusables = this.flattenArray(focusables);
+        this._contentFocusables = this.sortVisually(this.flattenArray(focusables));
 
         // Mark the default content focus, but only if it is actually a valid content focusable.
         this._lastContentFocus = this.isInContent(defaultFocus) && defaultFocus;
@@ -698,6 +698,29 @@ export class TXMFocusManager {
             if (newLane.start <= focusLane.start && focusLane.start < newLane.end) return true;
             return false;
         }
+    }
+
+    sortVisually(focusables) {
+        focusables.sort((f1, f2) => {
+            const bounds1 = f1.element && f1.element.getBoundingClientRect();
+            const bounds2 = f2.element && f2.element.getBoundingClientRect();
+
+            // Can encounter null bounds during testing with stubbed focusables.
+            if (!bounds1 && !bounds2) {
+                return 0;
+            } else if (!bounds1) {
+                return -1;
+            } else if (!bounds2) {
+                return 1;
+            }
+
+            var cmp = bounds1.top - bounds2.top;
+            if (cmp == 0) {
+                cmp = bounds1.left - bounds2.left;
+            }
+            return cmp;
+        });
+        return focusables;
     }
 
     flattenArray(array) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -659,14 +659,15 @@ export class TXMFocusManager {
 
                 // only look at focusables that are actually visually beyond the current focus edge
                 var newFocusDistance = getDistanceBeyondFocus(newBounds);
-                if (fromFocus !== newF && intersects(newBounds, focusBounds)) {
-                    // However, if two focusables actually visually intersect, we assume the develop knows this
-                    // and that things look visually ok. E.g. this happens with production choice cards, where
-                    // the Yes/No buttons technically have overlapping images, although the core visible content
-                    // does not overlap.
+                const focusIntersection = intersection(newBounds, focusBounds);
+                if (fromFocus !== newF && focusIntersection && !equals(focusIntersection, newBounds)) {
+                    // However, if two focusables actually visually intersect but not completely covers,
+                    // we assume the develop knows this and that things look visually ok. E.g. this happens
+                    // with production choice cards, where the Yes/No buttons technically have overlapping
+                    // images, although the core visible content does not overlap.
                     //
-                    // In this case, we measure between the two item center points instead of the leading edge that is beyond
-                    // the current focus.
+                    // In this case, we measure between the two item center points instead of the leading edge
+                    // that is beyond the current focus.
                     newFocusDistance = getCenterDistance(getBoundsCenter(newBounds), getBoundsCenter(focusBounds));
                     if (newFocusDistance <= 0) return; // center must be beyond the current focus
 
@@ -726,7 +727,7 @@ export class TXMFocusManager {
             return false;
         }
 
-        function intersects(bounds1, bounds2) {
+        function intersection(bounds1, bounds2) {
             const intersection = {
               top: Math.max(bounds1.top, bounds2.top),
               left: Math.max(bounds1.left, bounds2.left),
@@ -735,7 +736,14 @@ export class TXMFocusManager {
             };
             const w = intersection.right - intersection.left;
             const h = intersection.bottom - intersection.top;
-            return w > 0 && h > 0;
+            return w > 0 && h > 0 && intersection;
+        }
+
+        function equals(bounds1, bounds2) {
+            return bounds1.top == bounds2.top
+                && bounds1.left == bounds2.left
+                && bounds1.bottom == bounds2.bottom
+                && bounds1.right == bounds2.right;
         }
     }
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -657,7 +657,7 @@ export class TXMFocusManager {
                 const newRange = getRange(newF);
                 const newDistance = getDistance(newRange);
                 // only look at focusables that are actually visually beyond the current focus edge
-                if (newDistance <= 0) return;
+                if (newDistance < 0) return;
                 if (mustBeInVisualLane && !overlapsFocus(newRange)) return;
                 if (currResult) {
                     if (newDistance < currDistance) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -559,18 +559,13 @@ export class TXMFocusManager {
     }
 
     getFirstFocusIn(focusables) {
-        if (!Array.isArray(focusables)) return;
-        for (let rowIndex in focusables) {
-            let row = focusables[rowIndex];
-            if (!row) continue;
-            if (!Array.isArray(row)) return row; // Treat as an element.
-            for (let colIndex in row) {
-                let component = row[colIndex];
-                if (!component) continue;
-                if (Array.isArray(component)) continue; // shouldn't happen
-                return component;
+        if (Array.isArray(focusables)) {
+            for (let index in focusables) {
+                const f = focusables[index];
+                if (f) return f;
             }
         }
+        return undefined;
     }
 
     getLastFocus() {
@@ -581,18 +576,13 @@ export class TXMFocusManager {
     }
 
     getLastFocusIn(focusables) {
-        if (!Array.isArray(focusables)) return;
-        for (let rowIndex = focusables.length - 1; rowIndex >= 0; rowIndex--) {
-            let row = focusables[rowIndex];
-            if (!row) continue;
-            if (!Array.isArray(row)) return row; // Treat as an element.
-            for (let colIndex = row.length - 1; colIndex >= 0; colIndex--) {
-                let component = row[colIndex];
-                if (!component) continue;
-                if (Array.isArray(component)) continue; // shouldn't happen
-                return component;
+        if (Array.isArray(focusables)) {
+            for (let index = focusables.length - 1; index >= 0; index--) {
+                const f = focusables[index];
+                if (f) return f;
             }
         }
+        return undefined;
     }
 
     isInTopChrome(focusable) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -509,7 +509,7 @@ export class TXMFocusManager {
      */
     setTopChromeFocusables(focusables) {
         this._lastTopFocus = undefined;
-        this._topChromeFocusables = this.ensureArray(focusables);
+        this._topChromeFocusables = this.flattenArray(focusables);
     }
 
     /**
@@ -518,7 +518,7 @@ export class TXMFocusManager {
      */
     setBottomChromeFocusables(focusables) {
         this._lastBottomFocus = undefined;
-        this._bottomChromeFocusables = this.ensureArray(focusables);
+        this._bottomChromeFocusables = this.flattenArray(focusables);
     }
 
     /**
@@ -536,7 +536,7 @@ export class TXMFocusManager {
         const isInBottomChrome = this.isInBottomChrome(current);
         const resetFocus = !current || !isInTopChrome && !isInBottomChrome;
 
-        this._contentFocusables = this.ensureArray(focusables);
+        this._contentFocusables = this.flattenArray(focusables);
 
         // Mark the default content focus, but only if it is actually a valid content focusable.
         this._lastContentFocus = this.isInContent(defaultFocus) && defaultFocus;
@@ -699,9 +699,18 @@ export class TXMFocusManager {
         }
     }
 
-    ensureArray(array) {
-        if (!array) return []; // i.e. empty, no focusables
-        if (!Array.isArray(array)) return [array]; // treat as a single element array
-        return array;
+    flattenArray(array) {
+        const result = [];
+        traverse(array);
+        return result;
+
+        function traverse(currArray) {
+            if (!currArray) return;
+            if (Array.isArray(currArray)) {
+                currArray.forEach(traverse);
+            } else {
+                result.push(currArray); // found an element
+            }
+        }
     }
 }

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -630,14 +630,14 @@ export class TXMFocusManager {
         const focusLaneCenter = getLaneCenter(focusLane);
 
         // First try to find the best match in the same visual row or column.
-        var result = findBestResult(true);
+        var result = findNextClosestFocus(true);
         if (!result) {
             // Nothing in the same visual lane. Fallback to the first one beyond the current focus edge at all.
-            result = findBestResult(false);
+            result = findNextClosestFocus(false);
         }
         return result;
 
-        function findBestResult(mustBeInVisualLane) {
+        function findNextClosestFocus(mustBeInVisualLane) {
             var currResult;
             var currDistance;
             var currLaneDistance;

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -666,7 +666,7 @@ export class TXMFocusManager {
         }
 
         function getLaneCenter(laneRange) {
-            return (laneRange.end - laneRange.start) / 2;
+            return (laneRange.start + laneRange.end) / 2;
         }
 
         function getDistanceFromFocusLane(laneRange) {
@@ -691,8 +691,8 @@ export class TXMFocusManager {
         }
 
         function overlapsLane(newLane) {
-            if (focusLane.start <= newLane.start && newLane.start <= focusLane.end) return true;
-            if (newLane.start <= focusLane.start && focusLane.start <= newLane.end) return true;
+            if (focusLane.start <= newLane.start && newLane.start < focusLane.end) return true;
+            if (newLane.start <= focusLane.start && focusLane.start < newLane.end) return true;
             return false;
         }
     }

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -597,11 +597,6 @@ export class TXMFocusManager {
         return this._bottomChromeFocusables.indexOf(focusable) >= 0;
     }
 
-    hasFocusable(focusable) {
-        return focusable &&
-          (this.isInTopChrome(focusable) || this.isInContent(focusable) || this.isInBottomChrome(focusable));
-    }
-
     findNextFocus(fromFocus, forAction, inFocusables) {
         if (!fromFocus) return;
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -612,30 +612,30 @@ export class TXMFocusManager {
 
         const focusBounds = getBoundsOf(fromFocus);
 
-        var getRange;
-        var getDistance;
+        var getLaneRange;
+        var getDistanceBeyondFocus;
         switch (forAction) {
             case inputActions.moveRight:
-                getRange = bounds => { return {start: bounds.left, end: bounds.right} };
-                getDistance = range => range.start - focusBounds.right;
+                getLaneRange = bounds => { return {start: bounds.top, end: bounds.bottom} };
+                getDistanceBeyondFocus = newBounds => newBounds.left - focusBounds.right;
                 break;
             case inputActions.moveLeft:
-                getRange = bounds => { return {start: bounds.left, end: bounds.right} };
-                getDistance = range => focusBounds.left - range.end;
+                getLaneRange = bounds => { return {start: bounds.top, end: bounds.bottom} };
+                getDistanceBeyondFocus = newBounds => focusBounds.left - newBounds.right;
                 break;
             case inputActions.moveDown:
-                getRange = bounds => { return {start: bounds.top, end: bounds.bottom} };
-                getDistance = range => range.start - focusBounds.bottom;
+                getLaneRange = bounds => { return {start: bounds.left, end: bounds.right} };
+                getDistanceBeyondFocus = newBounds => newBounds.top - focusBounds.bottom;
                 break;
             case inputActions.moveUp:
-                getRange = bounds => { return {start: bounds.top, end: bounds.bottom} };
-                getDistance = range => focusBounds.top - range.end;
+                getLaneRange = bounds => { return {start: bounds.left, end: bounds.right} };
+                getDistanceBeyondFocus = newBounds => focusBounds.top - newBounds.bottom;
                 break;
             default:
                 // Not a movement action.
                 return;
         }
-        const focusRange = getRange(focusBounds);
+        const focusLane = getLaneRange(focusBounds);
 
         // First try to find the best match in the same visual row or column.
         var result = findBestResult(true);
@@ -650,11 +650,13 @@ export class TXMFocusManager {
             var currDistance;
             inFocusables.forEach(newF => {
                 const newBounds = getBoundsOf(newF);
-                const newRange = getRange(newBounds);
-                const newDistance = getDistance(newRange);
+                const newDistance = getDistanceBeyondFocus(newBounds);
                 // only look at focusables that are actually visually beyond the current focus edge
                 if (newDistance < 0) return;
-                if (mustBeInVisualLane && !overlapsFocus(newRange)) return;
+
+                const newRange = getLaneRange(newBounds);
+                if (mustBeInVisualLane && !overlapsFocusLane(newRange)) return;
+
                 if (currResult) {
                     if (newDistance < currDistance) {
                         // This focusable is closer to the current focus.
@@ -675,9 +677,9 @@ export class TXMFocusManager {
               || {top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0};
         }
 
-        function overlapsFocus(range) {
-            if (focusRange.start <= range.start && range.start <= focusRange.end) return true;
-            if (range.start <= focusRange.start && focusRange.start <= range.end) return true;
+        function overlapsFocusLane(newRange) {
+            if (focusLane.start <= newRange.start && newRange.start <= focusLane.end) return true;
+            if (newRange.start <= focusLane.start && focusLane.start <= newRange.end) return true;
             return false;
         }
     }

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -597,6 +597,10 @@ export class TXMFocusManager {
         return this._bottomChromeFocusables.indexOf(focusable) >= 0;
     }
 
+    hasFocusable(focusable) {
+        return this.isInTopChrome(focusable) || this.isInContent(focusable) || this.isInBottomChrome(focusable);
+    }
+
     findNextFocus(fromFocus, forAction, inFocusables) {
         if (!fromFocus) return;
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -607,15 +607,10 @@ export class TXMFocusManager {
         return this._bottomChromeFocusables.indexOf(focusable) >= 0;
     }
 
-    getBoundsOf(focusable) {
-        return focusable && focusable.element && focusable.element.getBoundingClientRect()
-          || {top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0};
-    }
-
     findNextFocus(fromFocus, forAction, inFocusables) {
         if (!fromFocus) return;
 
-        const focusBounds = this.getBoundsOf(fromFocus);
+        const focusBounds = getBoundsOf(fromFocus);
 
         var getRange;
         var getDistance;
@@ -654,7 +649,8 @@ export class TXMFocusManager {
             var currResult;
             var currDistance;
             inFocusables.forEach(newF => {
-                const newRange = getRange(newF);
+                const newBounds = getBoundsOf(newF);
+                const newRange = getRange(newBounds);
                 const newDistance = getDistance(newRange);
                 // only look at focusables that are actually visually beyond the current focus edge
                 if (newDistance < 0) return;
@@ -672,6 +668,11 @@ export class TXMFocusManager {
                 }
             });
             return currResult;
+        }
+
+        function getBoundsOf(focusable) {
+            return focusable && focusable.element && focusable.element.getBoundingClientRect()
+              || {top: 0, left: 0, bottom: 0, right: 0, width: 0, height: 0};
         }
 
         function overlapsFocus(range) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -640,6 +640,7 @@ export class TXMFocusManager {
             var currDistance;
             inFocusables.forEach(newF => {
                 const newBounds = getBoundsOf(newF);
+
                 const newDistance = getDistanceBeyondFocus(newBounds);
                 // only look at focusables that are actually visually beyond the current focus edge
                 if (newDistance < 0) return;


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2802
https://truextech.atlassian.net/browse/CTV-3307

### Description
* compute new focuses dynamically from current visual position

### Testing
* Run creative ad 5388 from Skyline in Chrome, unit tests.

### Commit Message Subject
CTV-2802: HTML5 - focus states is not updated after animation
CTV-3307: HTML5: ensure consistent focus navigation rules for bluescript

### Additional Context

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
