### PR TITLE
Bugfix/ctv 2698 prevent mouse click on hidden buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.3
+* [CTV-2698](https://truextech.atlassian.net/browse/CTV-3307): HTML5 - mouse click on hidden button still trigger it's actions
+
 ## v1.6.2
 * [CTV-3307](https://truextech.atlassian.net/browse/CTV-3307): HTML5: ensure consistent focus navigation rules for bluescript
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -112,6 +112,51 @@ describe("TXMFocusManager", () => {
         expect(inputAction).not.toHaveBeenCalled();
     });
 
+    describe("test focus mouse events enabled/disable", () => {
+        const fm = new TXMFocusManager();
+
+        const selectAction = jest.fn();
+
+        var mouseEnabled = true;
+
+        function testMouseEnabled() {
+            return mouseEnabled;
+        }
+
+        let testDiv = document.createElement("div");
+        testDiv.id = "clickableFocus";
+        testDiv.className = "coolButton";
+        document.body.appendChild(testDiv);
+
+        let clickableFocus = new Focusable(testDiv, selectAction);
+        clickableFocus.addMouseEventListeners(fm, testMouseEnabled);
+
+        const mouseEnter = document.createEvent('Event');
+        mouseEnter.initEvent("mouseenter", true, true);
+
+        clickableFocus.element.dispatchEvent(mouseEnter);
+        expect(fm.currentFocus).toBe(clickableFocus);
+
+        const mouseClick = document.createEvent('Event');
+        mouseClick.initEvent("click", true, true);
+
+        clickableFocus.element.dispatchEvent(mouseClick);
+        expect(selectAction).toHaveBeenCalled();
+
+        // Mouse events should not be ignored:
+        mouseEnabled = false;
+        selectAction.mockClear();
+
+        clickableFocus.element.dispatchEvent(mouseClick);
+        expect(fm.currentFocus).toBe(clickableFocus);
+        expect(selectAction).not.toHaveBeenCalled();
+
+        fm.setFocus(undefined);
+
+        clickableFocus.element.dispatchEvent(mouseEnter);
+        expect(fm.currentFocus).toBe(undefined);
+    });
+
     describe("focus manager optional onSelectAction callback", () => {
         const fm = new TXMFocusManager();
         fm.keyThrottleDelay = 0; // disable throttling for this test

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -143,7 +143,7 @@ describe("TXMFocusManager", () => {
         clickableFocus.element.dispatchEvent(mouseClick);
         expect(selectAction).toHaveBeenCalled();
 
-        // Mouse events should not be ignored:
+        // Mouse events should now be ignored:
         mouseEnabled = false;
         selectAction.mockClear();
 

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -112,7 +112,7 @@ describe("TXMFocusManager", () => {
         expect(inputAction).not.toHaveBeenCalled();
     });
 
-    describe("test focus mouse events enabled/disable", () => {
+    describe("test focus mouse events enabled/disabled", () => {
         const fm = new TXMFocusManager();
 
         const selectAction = jest.fn();

--- a/src/focus_manager/txm_focusable.js
+++ b/src/focus_manager/txm_focusable.js
@@ -46,6 +46,8 @@ export class Focusable {
      * If the associated element present, adds mouseEnter and click event listeners to
      * set the focus (for mouseEnter event), or invoke the select action (for click event).
      * @param focusManager the focus manager to use for setting the current focus in the mouseEnter listener.
+     * @param testMouseEnabled optional function to return true if mouse events are to be allowed. Mouse events are
+     *   ignored if false.
      */
     addMouseEventListeners(focusManager, testMouseEnabled) {
         const elmt = this.element;

--- a/src/focus_manager/txm_focusable.js
+++ b/src/focus_manager/txm_focusable.js
@@ -47,17 +47,19 @@ export class Focusable {
      * set the focus (for mouseEnter event), or invoke the select action (for click event).
      * @param focusManager the focus manager to use for setting the current focus in the mouseEnter listener.
      */
-    addMouseEventListeners(focusManager) {
+    addMouseEventListeners(focusManager, testMouseEnabled) {
         const elmt = this.element;
         if (elmt && elmt.addEventListener) {
             // Add mouse support if possible.
             if (focusManager) {
                 elmt.addEventListener('mouseenter', () => {
+                    if (testMouseEnabled && !testMouseEnabled()) return;
                     focusManager.setFocus(this);
                 });
             }
 
             elmt.addEventListener('click', event => {
+                if (testMouseEnabled && !testMouseEnabled()) return;
                 event.preventDefault();
                 event.stopPropagation();
                 event.stopImmediatePropagation();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,9 +1631,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001242"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz#04201627abcd60dc89211f22cbe2347306cda46b"
-  integrity sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==
+  version "1.0.30001286"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001286.tgz"
+  integrity sha512-zaEMRH6xg8ESMi2eQ3R4eZ5qw/hJiVsO/HlLwniIwErij0JDr9P+8V4dtx1l+kLq6j3yy8l8W4fst1lBnat5wQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2898

### Description
* block mouse events on hidden buttons

### Testing
* Unit tests, run creative ad 5276 from Skyline in Chrome.

### Commit Message Subject
CTV-2698: HTML5 - mouse click on hidden button still trigger it's actions

### Additional Context

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
