### PR TITLE
Bugfix/ctv 3321 move down focuses on upvote button instead of return to content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.4
+* [CTV-3321](https://truextech.atlassian.net/browse/CTV-3321): HTML5 - Clicking down focus on upvote button instead of return to content
+
 ## v1.6.3
 * [CTV-2698](https://truextech.atlassian.net/browse/CTV-3307): HTML5 - mouse click on hidden button still trigger it's actions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -578,7 +578,6 @@ describe("TXMFocusManager", () => {
 
         describe("chrome to content navigation", () => {
             const fm = new TXMFocusManager();
-
             const topChrome = newFocusRows({x: 0, y: 0, prefix: 'topChrome', count: 4});
             const bottomChrome = newFocusRows({x: 0, y: 100, prefix: 'bottomChrome', count: 4});
 
@@ -697,22 +696,45 @@ describe("TXMFocusManager", () => {
                 fm.navigateToNewFocus(inputActions.moveDown);
                 expect(fm.currentFocus).toBe(focuses[2]);
             });
+        });
 
-            describe("custom default chrome focusables", () => {
-                fm.setTopChromeFocusables([topChrome[1], topChrome[2], topChrome[3]], topChrome[2]);
-                fm.setBottomChromeFocusables([bottomChrome[1], bottomChrome[2]], bottomChrome[2]);
-                fm.setContentFocusables([focuses[1], focuses[2], focuses[3]], focuses[2]);
+        describe("custom default chrome focusables", () => {
+            const fm = new TXMFocusManager();
+            const topChrome = newFocusRows({x: 0, y: 0, prefix: 'topChrome', count: 4});
+            const bottomChrome = newFocusRows({x: 0, y: 100, prefix: 'bottomChrome', count: 4});
+            fm.setTopChromeFocusables([topChrome[1], topChrome[2], topChrome[3]], topChrome[2]);
+            fm.setBottomChromeFocusables([bottomChrome[1], bottomChrome[2]], bottomChrome[2]);
+            fm.setContentFocusables([focuses[1], focuses[2], focuses[3]], focuses[2]);
 
-                test("overall default focus and use customized chrome focusables", () => {
-                    fm.setFocus(undefined);
-                    expect(fm.getFirstFocus()).toBe(focuses[1]);
+            test("move from content to default top chrome focus", () => {
+                fm.setFocus(focuses[1]);
 
-                    fm.setContentFocusables(undefined);
-                    expect(fm.getFirstFocus()).toBe(topChrome[2]);
+                fm.navigateToNewFocus(inputActions.moveUp);
+                expect(fm.currentFocus).toBe(topChrome[2]);
 
-                    fm.setTopChromeFocusables(undefined);
-                    expect(fm.getFirstFocus()).toBe(bottomChrome[2]);
-                });
+                fm.navigateToNewFocus(inputActions.moveDown);
+                expect(fm.currentFocus).toBe(focuses[1]);
+            });
+
+            test("move from content to default bottom chrome focus", () => {
+                fm.setFocus(focuses[1]);
+
+                fm.navigateToNewFocus(inputActions.moveDown);
+                expect(fm.currentFocus).toBe(bottomChrome[2]);
+
+                fm.navigateToNewFocus(inputActions.moveUp);
+                expect(fm.currentFocus).toBe(focuses[1]);
+            });
+
+            test("overall default focus and use customized chrome focusables", () => {
+                fm.setFocus(focuses[3]);
+                expect(fm.getDefaultFocus()).toBe(focuses[3]);
+
+                fm.setContentFocusables(undefined);
+                expect(fm.getDefaultFocus()).toBe(topChrome[2]);
+
+                fm.setTopChromeFocusables(undefined);
+                expect(fm.getDefaultFocus()).toBe(bottomChrome[2]);
             });
         });
     });

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -697,6 +697,23 @@ describe("TXMFocusManager", () => {
                 fm.navigateToNewFocus(inputActions.moveDown);
                 expect(fm.currentFocus).toBe(focuses[2]);
             });
+
+            describe("custom default chrome focusables", () => {
+                fm.setTopChromeFocusables([topChrome[1], topChrome[2], topChrome[3]], topChrome[2]);
+                fm.setBottomChromeFocusables([bottomChrome[1], bottomChrome[2]], bottomChrome[2]);
+                fm.setContentFocusables([focuses[1], focuses[2], focuses[3]], focuses[2]);
+
+                test("overall default focus and use customized chrome focusables", () => {
+                    fm.setFocus(undefined);
+                    expect(fm.getFirstFocus()).toBe(focuses[1]);
+
+                    fm.setContentFocusables(undefined);
+                    expect(fm.getFirstFocus()).toBe(topChrome[2]);
+
+                    fm.setTopChromeFocusables(undefined);
+                    expect(fm.getFirstFocus()).toBe(bottomChrome[2]);
+                });
+            });
         });
     });
 });

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -557,8 +557,8 @@ export class TXMFocusManager {
 
     getFirstFocus() {
         let focus = this.getFirstFocusIn(this._contentFocusables);
-        if (!focus) focus = this._topChromeFocusables || this.getFirstFocusIn(this._topChromeFocusables);
-        if (!focus) focus = this._bottomChromeFocusables || this.getFirstFocusIn(this._bottomChromeFocusables);
+        if (!focus) focus = this._lastTopFocus || this.getFirstFocusIn(this._topChromeFocusables);
+        if (!focus) focus = this._lastBottomFocus || this.getFirstFocusIn(this._bottomChromeFocusables);
         return focus;
     }
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -347,7 +347,7 @@ export class TXMFocusManager {
         let focus = this.currentFocus;
         // if no element is currently focused, and the user is attempting to navigate or select, set default focus
         if (!focus && (inputActions.isMovementAction(action) || action == inputActions.select)) {
-            focus = this.getFirstFocus();
+            focus = this.getDefaultFocus();
             this.setFocus(focus);
             return true;
         }
@@ -405,7 +405,7 @@ export class TXMFocusManager {
         let focus = this.currentFocus;
         if (!focus) {
             // No focus yet, establish it.
-            this.setFocus(this.getFirstFocus());
+            this.setFocus(this.getDefaultFocus());
             return;
         }
 
@@ -444,7 +444,7 @@ export class TXMFocusManager {
             }
         } else {
             // Current focus not found, fallback.
-            newFocus = this.getFirstFocus();
+            newFocus = this.getDefaultFocus();
         }
 
         if (newFocus) {
@@ -555,8 +555,8 @@ export class TXMFocusManager {
         }
     }
 
-    getFirstFocus() {
-        let focus = this.getFirstFocusIn(this._contentFocusables);
+    getDefaultFocus() {
+        let focus = this._lastContentFocus || this.getFirstFocusIn(this._contentFocusables);
         if (!focus) focus = this._lastTopFocus || this.getFirstFocusIn(this._topChromeFocusables);
         if (!focus) focus = this._lastBottomFocus || this.getFirstFocusIn(this._bottomChromeFocusables);
         return focus;

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -506,19 +506,23 @@ export class TXMFocusManager {
     /**
      * Used by the true[X] framework to specify the focusable control buttons along the top of the current page.
      * @param focusables array of focusable components, typically extending the {Focusable} class
+     * @param defaultTopFocus optional, if present, it indicates which top chrome focusable to move to when
+     *   moving up from the content area.
      */
-    setTopChromeFocusables(focusables) {
-        this._lastTopFocus = undefined;
+    setTopChromeFocusables(focusables, defaultTopFocus) {
         this._topChromeFocusables = this.sortVisually(this.flattenArray(focusables));
+        this._lastTopFocus =  this.isInTopChrome(defaultTopFocus) ? defaultTopFocus : undefined;
     }
 
     /**
      * Used by the true[X] framework to specify the focusable control buttons along the bottom of the current page.
      * @param focusables array of focusable components, typically extending the {Focusable} class
+     * @param defaultBottomFocus optional, if present, it indicates which bottom chrome focusable to move to when
+     *   moving down from the content area.
      */
-    setBottomChromeFocusables(focusables) {
-        this._lastBottomFocus = undefined;
+    setBottomChromeFocusables(focusables, defaultBottomFocus) {
         this._bottomChromeFocusables = this.sortVisually(this.flattenArray(focusables));
+        this._lastBottomFocus = this.isInBottomChrome(defaultBottomFocus) ? defaultBottomFocus : undefined;
     }
 
     /**
@@ -539,7 +543,7 @@ export class TXMFocusManager {
         this._contentFocusables = this.sortVisually(this.flattenArray(focusables));
 
         // Mark the default content focus, but only if it is actually a valid content focusable.
-        this._lastContentFocus = this.isInContent(defaultFocus) && defaultFocus;
+        this._lastContentFocus = this.isInContent(defaultFocus) ? defaultFocus : undefined;
 
         if (resetFocus) {
             if (!defaultFocus) {
@@ -553,8 +557,8 @@ export class TXMFocusManager {
 
     getFirstFocus() {
         let focus = this.getFirstFocusIn(this._contentFocusables);
-        if (!focus) focus = this.getFirstFocusIn(this._topChromeFocusables);
-        if (!focus) focus = this.getFirstFocusIn(this._bottomChromeFocusables);
+        if (!focus) focus = this._topChromeFocusables || this.getFirstFocusIn(this._topChromeFocusables);
+        if (!focus) focus = this._bottomChromeFocusables || this.getFirstFocusIn(this._bottomChromeFocusables);
         return focus;
     }
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3321

### Description
* ensure "return to content" button is default focus for bottom chrome

### Testing
* Unit tests, run "Date Demo" creative ad 5590 from Skyline in Chrome.

### Commit Message Subject
CTV-3321: HTML5 - Clicking down focus on upvote button instead of return to content

### Additional Context

### Related PRs

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
