### PR TITLE
Bugfix/ctv 2446 focus navigation bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.5
+* [CTV-2446](https://truextech.atlassian.net/browse/CTV-2446): Clean Up Skyline Ad Tags
+
 ## v1.6.4
 * [CTV-3321](https://truextech.atlassian.net/browse/CTV-3321): HTML5 - Clicking down focus on upvote button instead of return to content
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.6.5
+## v1.6.6
 * [CTV-2446](https://truextech.atlassian.net/browse/CTV-2446): Clean Up Skyline Ad Tags
 
 ## v1.6.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -355,6 +355,30 @@ describe("complex navigation tests", () => {
     testInput(BBB,left, BBB);
   });
 
+  test("test misaligned button row", () => {
+    const AA = newFocusable("AA", {x: 10, y: 0, w: 5, h: 20});
+    const BB = newFocusable("BB", {x: 0, y: 10, w: 5, h: 20});
+    const CC = newFocusable("CC", {x: 20, y: 10, w: 5, h: 20});
+
+    //   A
+    // B A C
+    // B   C
+    focusManager.setContentFocusables([BB, AA, CC]);
+
+    testInput(AA, left, BB);
+    testInput(AA, right, CC);
+    testInput(AA, up, AA);
+    testInput(AA, down, AA);
+    testInput(BB, up, BB);
+    testInput(BB, down, BB);
+    testInput(BB, left, BB);
+    testInput(BB, right, AA);
+    testInput(CC, up, CC);
+    testInput(CC, down, CC);
+    testInput(CC, left, AA);
+    testInput(CC, right, CC);
+  });
+
   test("test multiple matches in focus column", () => {
     const AAA = newFocusable("AAA", {x: 30, y: 10, w: 10, h: 10});
     const BBB = newFocusable("BBB", {x: 80, y: 10, w: 10, h: 10});
@@ -418,6 +442,33 @@ describe("complex navigation tests", () => {
     D.element.setBounds({y: Z.element.y - D.element.height});
     testInput(Z, left, B);
     testInput(Z, right, E);
+  });
+
+  test("test closes outside focus column", () => {
+    const A = newFocusable("A", {x: 10, y: 0, w: 5, h: 5});
+    const B = newFocusable("B", {x: 0, y: 10, w: 5, h: 5});
+    const C = newFocusable("C", {x: 20, y: 10, w: 5, h: 5});
+
+    //   A
+    // B   C
+    focusManager.setContentFocusables([A, B, C]);
+
+    testInput(A, left, B);
+    testInput(A, right, C);
+    testInput(A, up, A);
+    testInput(A, down, B);
+    testInput(B, up, A);
+    testInput(B, down, B);
+    testInput(B, left, B);
+    testInput(B, right, C);
+    testInput(C, up, A);
+    testInput(C, down, C);
+    testInput(C, left, B);
+    testInput(C, right, C);
+
+    // Move C closer to A's column. It should then take priority vs B.
+    C.element.setBounds({x: A.element.right + 1});
+    testInput(A, down, C);
   });
 
   test("test button completely covering another", () => {

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -444,7 +444,7 @@ describe("complex navigation tests", () => {
     testInput(Z, right, E);
   });
 
-  test("test closes outside focus column", () => {
+  test("test closest outside focus column", () => {
     const A = newFocusable("A", {x: 10, y: 0, w: 5, h: 5});
     const B = newFocusable("B", {x: 0, y: 10, w: 5, h: 5});
     const C = newFocusable("C", {x: 20, y: 10, w: 5, h: 5});

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -81,6 +81,8 @@ describe("TXMFocusManager", () => {
 
         const mouseEnter = document.createEvent('Event');
         mouseEnter.initEvent("mouseenter", true, true);
+        mouseEnter.screenX = 2;
+        mouseEnter.screenY = 2;
 
         focus3.element.dispatchEvent(mouseEnter);
         expect(fm.currentFocus).toBe(focus3);
@@ -133,6 +135,8 @@ describe("TXMFocusManager", () => {
 
         const mouseEnter = document.createEvent('Event');
         mouseEnter.initEvent("mouseenter", true, true);
+        mouseEnter.screenX = 1;
+        mouseEnter.screenY = 1;
 
         clickableFocus.element.dispatchEvent(mouseEnter);
         expect(fm.currentFocus).toBe(clickableFocus);

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -149,6 +149,7 @@ describe("TXMFocusManager", () => {
         clickableFocus.element.dispatchEvent(mouseEnter);
         expect(fm.currentFocus).toBe(clickableFocus);
 
+        // Verify onFocusSet callback args with mouse related focus changes.
         expect(lastHasFocus).toBe(true);
         expect(lastFocusChange && lastFocusChange.oldFocus).toBe(undefined);
         expect(lastFocusChange && lastFocusChange.newFocus).toBe(clickableFocus);

--- a/src/focus_manager/__tests__/txm_focus_manager-test.js
+++ b/src/focus_manager/__tests__/txm_focus_manager-test.js
@@ -405,7 +405,12 @@ describe("TXMFocusManager", () => {
                     return {x, y, width: w, height: h, top: y, left: x, right: x + w, bottom: y + h};
                 }
             };
-            return new Focusable(element);
+            const f = new Focusable(element);
+            f.onFocusSet = function(hasFocus, focusChange) {
+              f.hasFocus = hasFocus;
+              f.focusChange = focusChange;
+            };
+            return f;
         }
 
         function newFocusRows(...rowBounds) {
@@ -514,6 +519,15 @@ describe("TXMFocusManager", () => {
 
                 fm.onInputAction(inputActions.moveRight);
                 expect(fm.currentFocus).toBe(focuses[3]);
+
+                // Verify onFocusSet callback args.
+                expect(focuses[2].hasFocus).toBe(false);
+                expect(focuses[3].hasFocus).toBe(true);
+                expect(focuses[2].focusChange).toBe(focuses[3].focusChange);
+                expect(focuses[3].focusChange.oldFocus).toBe(focuses[2]);
+                expect(focuses[3].focusChange.newFocus).toBe(focuses[3]);
+                expect(focuses[3].focusChange.action).toBe(inputActions.moveRight);
+                expect(focuses[3].focusChange.event).toBe(undefined);
             });
 
             test("No loss of focus moving right off of right side", () => {

--- a/src/focus_manager/txm_focus_change.js
+++ b/src/focus_manager/txm_focus_change.js
@@ -1,0 +1,19 @@
+import { inputActions } from './txm_input_actions';
+
+/**
+ * Describes the context of a focus change. Used to allow variations on focus processing
+ * based on keyboard navigation vs mouse movement.
+ *
+ * E.g. one often wants auto-scrolling
+ * into view of the new focus, but not when hovering over with the mouse.
+ */
+export class FocusChange {
+    constructor(oldFocus, newFocus, inputAction, inputEvent) {
+        this.oldFocus = oldFocus;
+        this.newFocus = newFocus;
+        this.action = inputAction;
+        this.event = inputEvent;
+    }
+}
+
+export default FocusChange;

--- a/src/focus_manager/txm_focus_change.js
+++ b/src/focus_manager/txm_focus_change.js
@@ -4,8 +4,7 @@ import { inputActions } from './txm_input_actions';
  * Describes the context of a focus change. Used to allow variations on focus processing
  * based on keyboard navigation vs mouse movement.
  *
- * E.g. one often wants auto-scrolling
- * into view of the new focus, but not when hovering over with the mouse.
+ * E.g. one often wants auto-scrolling into view of the new focus, but not when hovering over with the mouse.
  */
 export class FocusChange {
     constructor(oldFocus, newFocus, inputAction, inputEvent) {

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -36,6 +36,10 @@ export class TXMFocusManager {
         this._lastKeyCode = undefined;
         this._lastKeyEventTimestamp = 0;
 
+        // Used to filter out spurious mouseenter events.
+        this.lastMouseX = undefined;
+        this.lastMouseY = undefined;
+
         // make convenient for direct callbacks
         this.onKeyDown = this.onKeyDown.bind(this);
         this.onInputAction = this.onInputAction.bind(this);

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -71,7 +71,7 @@ export class TXMFocusManager {
 
         const inputAction = typeof fromInputActionOrEvent == 'string' ? fromInputActionOrEvent : undefined;
         const inputEvent = fromInputActionOrEvent instanceof Event ? fromInputActionOrEvent : undefined;
-        const focusChange = new FocusChange(oldFocus, newFocus, inputAction, inputAction);
+        const focusChange = new FocusChange(oldFocus, newFocus, inputAction, inputEvent);
 
         if (oldFocus && oldFocus.onFocusSet) oldFocus.onFocusSet(false, focusChange);
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -55,14 +55,19 @@ export class TXMFocusManager {
         return this._focus;
     }
 
-    setFocus(newFocus) {
+    /**
+     * Sets the current focus, invoking onFocusSet(false) on the old focus, onFocusSet(true) on the new focus.
+     * @param newFocus the new focusable item
+     * @param fromMouseEvent optional, indicates the focus is set from a mouse event, passed to onFocusSet if present.
+     */
+    setFocus(newFocus, fromMouseEvent) {
         let oldFocus = this.currentFocus;
         if (oldFocus === newFocus) return;
         this._focus = newFocus || undefined;
-        if (oldFocus && oldFocus.onFocusSet) oldFocus.onFocusSet(false);
+        if (oldFocus && oldFocus.onFocusSet) oldFocus.onFocusSet(false, fromMouseEvent);
         if (newFocus) {
             this._saveLastFocus(newFocus, newFocus);
-            if (newFocus.onFocusSet) newFocus.onFocusSet(true);
+            if (newFocus.onFocusSet) newFocus.onFocusSet(true, fromMouseEvent);
         } else {
             // We are clearing the focus completely.
             this._saveLastFocus(undefined, oldFocus);

--- a/src/focus_manager/txm_focusable.js
+++ b/src/focus_manager/txm_focusable.js
@@ -99,8 +99,8 @@ export class Focusable {
      * DOM element.
      *
      * @param hasFocus has focus if true, false if otherwise.
-     * @param {FocusChange} focusChange describe the detailed context of the focus change,
-     *   e.g. old vs new focusables, the input action or event. This allows for mouse vs keyboard specific processing.
+     * @param {FocusChange} focusChange describe the detailed context of the focus change, such as
+     *   old vs new focusables, the input action or event. This allows for mouse vs keyboard specific processing.
      *   E.g. auto-scrolling new focuses is usually desirable with keyboard navigation, but not with mouse hovering
      *   causing focus changes.
      */

--- a/src/focus_manager/txm_focusable.js
+++ b/src/focus_manager/txm_focusable.js
@@ -1,9 +1,6 @@
 import { inputActions } from './txm_input_actions';
 import { FocusChange } from './txm_focus_change';
 
-var lastMouseX;
-var lastMouseY;
-
 /**
  * Describes the method signatures that should be supported for a component to
  * participate with the notion of having/being the current focus.
@@ -62,10 +59,10 @@ export class Focusable {
                 // actually moved by the user (as opposed to the view scrolling underneath the mouse).
                 elmt.addEventListener('mouseenter', event => {
                     if (testMouseEnabled && !testMouseEnabled()) return;
-                    if (lastMouseX == event.screenX && lastMouseY == event.screenY) return;
+                    if (focusManager.lastMouseX == event.screenX && focusManager.lastMouseY == event.screenY) return;
                     focusManager.setFocus(this, event);
-                    lastMouseX = event.screenX;
-                    lastMouseY = event.screenY;
+                    focusManager.lastMouseX = event.screenX;
+                    focusManager.lastMouseY = event.screenY;
                 });
             }
 

--- a/src/focus_manager/txm_focusable.js
+++ b/src/focus_manager/txm_focusable.js
@@ -1,4 +1,5 @@
 import { inputActions } from './txm_input_actions';
+import { FocusChange } from './txm_focus_change';
 
 var lastMouseX;
 var lastMouseY;
@@ -101,11 +102,12 @@ export class Focusable {
      * DOM element.
      *
      * @param hasFocus has focus if true, false if otherwise.
-     * @param fromMouseEvent optional, indicates the focus is set from a mouse event, allowing for mouse vs keyboard
-     *   specific processing. E.g. auto-scrolling new focuses is usually desirable with keyboard navigation, but
-     *   not with mouse hovering causing focus changes.
+     * @param {FocusChange} focusChange describe the detailed context of the focus change,
+     *   e.g. old vs new focusables, the input action or event. This allows for mouse vs keyboard specific processing.
+     *   E.g. auto-scrolling new focuses is usually desirable with keyboard navigation, but not with mouse hovering
+     *   causing focus changes.
      */
-    onFocusSet(hasFocus, fromMouseEvent) {
+    onFocusSet(hasFocus, focusChange) {
         let e = this.element;
         if (!e) return;
         if (hasFocus) {


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2466

### Description
* Can navigate directly between ad tag sections now.
* Focus manager onFocusSet callbacks now include a FocusChange context to allow mouse vs keyboard custom processing.
* [A feature branch](https://qa-media.truex.com/branch-test/skyline/task_ctv-2446-clean-up-skyline-ad-tags/index.html) is available for testing

### Testing
* Ran Skyline, unit tests.

### Commit Message Subject
CTV-2466: Clean Up Skyline Ad Tags

### Additional Context

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
