### PR TITLE
Bugfix/ctv 3393 footer navigation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.7
+* [CTV-3393](https://truextech.atlassian.net/browse/CTV-3393): HTML5: navigation to "return to content" should be more direct
+
 ## v1.6.6
 * [CTV-2446](https://truextech.atlassian.net/browse/CTV-2446): Clean Up Skyline Ad Tags
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -610,4 +610,42 @@ describe("complex navigation tests", () => {
     testInput(BBB, down, BBB);
     testInput(BBB, up, AAA);
   });
+
+  test("test survey with help vs exit ad in footer", () => {
+    const A = newFocusable("A", {x: 100, y: 10, w: 50, h: 50});
+    const B = newFocusable("B", {x: 200, y: 10, w: 50, h: 50});
+    const C = newFocusable("C", {x: 300, y: 10, w: 50, h: 50});
+
+    const help = newFocusable("Help", {x: 10, y: 100, w: 50, h: 20});
+
+    const exitAd = newFocusable("exitAd", {x: 300, y: 1000, w: 50, h: 20});
+    const thumbsUp = newFocusable("thumbsUp", {x: 260, y: 1000, w: 10, h: 10});
+    const thumbsDown = newFocusable("thumbsDown", {x: 280, y: 1000, w: 10, h: 10});
+
+    focusManager.setContentFocusables([
+            A, B, C,
+      help
+    ]);
+
+    testAllInputs(A, help, B, null, help);
+    testAllInputs(B, A, C, null, help);
+    testAllInputs(C, B, null, null, help);
+    testAllInputs(help, null, A, A, null);
+
+    // Now show the footer, navigation to exit button should be natural as per focus lane rules,
+    // but only on move down. thumbs up/down buttons should not be considered.
+    focusManager.setBottomChromeFocusables([thumbsUp, thumbsDown, exitAd], exitAd);
+
+    testAllInputs(A, help, B, null, help); // help is closer to the down focus lane of A
+    testAllInputs(B, A, C, null, exitAd);
+    testAllInputs(C, B, null, null, exitAd);
+    testAllInputs(help, null, A, A, exitAd);
+
+    testAllInputs(help, null, A, A, exitAd);
+
+    // help is now the last content focus, and thus the return target moving off of the footer:
+    testAllInputs(exitAd, thumbsDown, help, null);
+    testAllInputs(thumbsDown, thumbsUp, help, exitAd);
+  });
+
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -203,11 +203,12 @@ describe("complex navigation tests", () => {
 
   test("test stepping up and down", () => {
     const A = newFocusable("A", {x: 30, y: 10, w: 10, h: 10});
-    const B = newFocusable("B", {x: 10, y: 30, w: 10, h: 10});
-    const C = newFocusable("C", {x: 90, y: 90, w: 10, h: 10});
+    const B = newFocusable("B", {x: 10, y: 900, w: 10, h: 10});
+    const C = newFocusable("C", {x: 90, y: 1000, w: 10, h: 10});
 
     focusManager.setContentFocusables([
          A,
+    // ... 880 pixels to top of B
       B,
             C
     ]);
@@ -218,7 +219,7 @@ describe("complex navigation tests", () => {
     testInput(B, right, A);
     testInput(B, down, C);
     testInput(C, up, B);
-    testInput(C, left, A);
+    testInput(C, left, B); // B is visually vertically closer to the focus lane moving left from C
     testInput(A, left, B);
   });
 

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -644,8 +644,8 @@ describe("complex navigation tests", () => {
     testAllInputs(help, null, A, A, exitAd);
 
     // help is now the last content focus, and thus the return target moving off of the footer:
-    testAllInputs(exitAd, thumbsDown, help, null);
-    testAllInputs(thumbsDown, thumbsUp, help, exitAd);
+    testAllInputs(exitAd, thumbsDown, null, help, null);
+    testAllInputs(thumbsDown, thumbsUp, exitAd, help, null);
   });
 
 });

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -641,8 +641,6 @@ describe("complex navigation tests", () => {
     testAllInputs(C, B, null, null, exitAd);
     testAllInputs(help, null, A, A, exitAd);
 
-    testAllInputs(help, null, A, A, exitAd);
-
     // help is now the last content focus, and thus the return target moving off of the footer:
     testAllInputs(exitAd, thumbsDown, null, help, null);
     testAllInputs(thumbsDown, thumbsUp, exitAd, help, null);

--- a/src/focus_manager/__tests__/focus-navigation-test.js
+++ b/src/focus_manager/__tests__/focus-navigation-test.js
@@ -216,10 +216,10 @@ describe("complex navigation tests", () => {
     testInput(A, down, B);
     testInput(A, left, B);
     testInput(B, up, A);
-    testInput(B, right, A);
+    testInput(B, right, C); // C is vertically closer to the focus lane moving right from B.
     testInput(B, down, C);
-    testInput(C, up, B);
-    testInput(C, left, B); // B is visually vertically closer to the focus lane moving left from C
+    testInput(C, up, A); // A is horizontally closer to the focus lane moving up from C
+    testInput(C, left, B); // B is vertically closer to the focus lane moving left from C
     testInput(A, left, B);
   });
 

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -711,6 +711,7 @@ export class TXMFocusManager {
                 } else {
                     // For items outside of the focus lane, distance to the focus lane matters first,
                     // then closest to focus after that.
+                    // I.e. we are deriving the minimum-width focus lane that includes a possible target.
                     isBetterMatch = newMatchDistance < currMatchDistance
                         || newMatchDistance == currMatchDistance && newBeyondDistance < currDistanceBeyondFocus;
                 }

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -436,8 +436,16 @@ export class TXMFocusManager {
             }
 
         } else if (this.isInContent(focus)) {
-            // Focus is in the content area.
-            newFocus = this.findNextFocus(focus, action, this._contentFocusables);
+            // Focus is in the content area. If we are possibly moving to a footer, try allow a move to it via the
+            // the "natural" focus lane rules first.
+            var possibleFocusables = this._contentFocusables;
+            if (action == inputActions.moveUp && this._lastTopFocus) {
+                possibleFocusables = possibleFocusables.concat(this._lastTopFocus);
+            } else if (action == inputActions.moveDown && this._lastBottomFocus) {
+                possibleFocusables = possibleFocusables.concat(this._lastBottomFocus);
+            }
+
+            newFocus = this.findNextFocus(focus, action, possibleFocusables);
             if (!newFocus) {
                 if (action == inputActions.moveUp) {
                     newFocus = this._lastTopFocus || this.getFirstFocusIn(this._topChromeFocusables);

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -662,31 +662,6 @@ export class TXMFocusManager {
         return result;
 
         function findNextClosestFocus(mustOverlapFocusLane) {
-            var getFocusMatchDistance;
-            if (mustOverlapFocusLane) {
-                // Use the distance to the left/top edge of the focus lane.
-                getFocusMatchDistance = newRange => {
-                    const overlapRange = {
-                        start: Math.max(newRange.start, focusLane.start),
-                        end: Math.min(newRange.end, focusLane.end)
-                    };
-
-                    const newOverlap = overlapRange.end - overlapRange.start;
-                    if (newOverlap <= 0) return; // only consider items actually overlapping the focus lane
-
-                    const newDistance = newRange.start - focusLane.start; // i.e. distance to left/top edge of focus lane
-                    return newDistance;
-                };
-            } else {
-                // Use the distance to the closest edge of the focus lane.
-                getFocusMatchDistance = newRange => {
-                    const newDistance = (newRange.end <= focusLane.end)
-                      ? focusLane.end - newRange.end // i.e. to the left/top of the focus lane
-                      : newRange.start - focusLane.start; // to the right/bottom of the focus lane
-                    return newDistance;
-                };
-            }
-
             var currResult;
             var currDistanceBeyondFocus;
             var currMatchDistance;
@@ -720,7 +695,7 @@ export class TXMFocusManager {
                 }
 
                 const newRange = getLaneRange(newBounds);
-                const newMatchDistance = getFocusMatchDistance(newRange);
+                const newMatchDistance = getFocusMatchDistance(newRange, mustOverlapFocusLane);
                 if (newMatchDistance === undefined) return; // ignoring item
 
                 var isBetterMatch;
@@ -771,6 +746,29 @@ export class TXMFocusManager {
                 && bounds1.left == bounds2.left
                 && bounds1.bottom == bounds2.bottom
                 && bounds1.right == bounds2.right;
+        }
+
+        function getFocusMatchDistance(newRange, mustOverlapFocusLane) {
+            if (mustOverlapFocusLane) {
+                // Use the distance to the left/top edge of the focus lane.
+                const overlapRange = {
+                    start: Math.max(newRange.start, focusLane.start),
+                    end: Math.min(newRange.end, focusLane.end)
+                };
+
+                const newOverlap = overlapRange.end - overlapRange.start;
+                if (newOverlap <= 0) return; // only consider items actually overlapping the focus lane
+
+                const newDistance = newRange.start - focusLane.start; // i.e. distance to left/top edge of focus lane
+                return newDistance;
+
+            } else {
+                // Use the distance to the closest edge of the focus lane.
+                const newDistance = (newRange.end <= focusLane.end)
+                  ? focusLane.end - newRange.end // i.e. to the left/top of the focus lane
+                  : newRange.start - focusLane.start; // to the right/bottom of the focus lane
+                return newDistance;
+            }
         }
     }
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3393

### Description
* Ensure navigation to footer follows "natural" focus lane navigation rules.
* Ensure consistent "minimum focus lane" idea for out-of-lane items.

### Testing
* Ran Skyline, unit tests.

### Commit Message Subject
CTV-3393: HTML5: navigation to "return to content" should be more direct

### Additional Context

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
