### PR TITLE
[SPLY-47] Handle string encoded JSON in VAST config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+cache: yarn
+language: node_js
+node_js: 16
+script: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 cache: yarn
 language: node_js
-node_js: 16
+node_js: 14
 script: yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.9
+* [SPLY-47](https://truextech.atlassian.net/browse/SPLY-47): Handle VPAID ad payload when determining TrueX URLs
+
 ## v1.6.8
 * [CTV-3380](https://truextech.atlassian.net/browse/CTV-3380): HTML5 - Inconsistency in (and lack of definition for) Bluescript string replace operation
     * Use latest babel, core-jss

--- a/README.md
+++ b/README.md
@@ -31,22 +31,22 @@ yarn install
 
 As this is a reusable library of JS classes and functions, any building/running in this repo is primarily done in the context of unit tests.
 
-Please your tests in a __tests__ sub directory of your relevant files. The convention is to add a -test.js suffix for a given source files.
+Place your tests in a __tests__ sub directory of your relevant files. The convention is to add a -test.js suffix for a given source files.
 
 To run the test suite you can do: `npm test` or `jest`
 
 Or for a single test: `npm test -- platform`
 or: `jest focus_manager`
-i.e. use a test file name pattern that will match the 
+i.e. use a test file name pattern that will match the
 
 ## Deploying
 
 To make this library available to other repos, be sure to push any changes and follow the normal review process.
 
-Ensure the version number in package.json is updated to a newer value, and be sure to tag your branch in github with 
+Ensure the version number in package.json is updated to a newer value, and be sure to tag your branch in github with
 the same version, e.g. `v1.0.0` .
 
-In client repos, one should refer to this library using the package name, github repo url, and desired version 
+In client repos, one should refer to this library using the package name, github repo url, and desired version
 number, e.g.
 ```
     dependencies: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -45,6 +45,12 @@ describe("truex_servers testing", () => {
         const demoConfig = {ads: [], "service_url": "measure.truex.com"};
         verifyServers(new TruexServers(demoConfig), true);
 
+        const vastSoloTagProdConfig = {AdParameters: JSON.stringify(prodConfig)};
+        verifyServers(new TruexServers(vastSoloTagProdConfig), true);
+
+        const vastSoloTagQAConfig = {AdParameters: JSON.stringify(qaConfig)};
+        verifyServers(new TruexServers(vastSoloTagQAConfig), false);
+
         function verifyServers(servers, isProd) {
             expect(servers.isProduction).toBe(isProd);
 

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -16,6 +16,9 @@ export function isTruexProductionUrl(url) {
 export class TruexServers {
     constructor(vastConfigOrUrlOrFlag) {
         var isProd = false; // by default
+        if (vastConfigOrUrlOrFlag && vastConfigOrUrlOrFlag.AdParameters) {
+            vastConfigOrUrlOrFlag = JSON.parse(vastConfigOrUrlOrFlag.AdParameters)
+        }
 
         if (typeof vastConfigOrUrlOrFlag == 'boolean') {
             isProd = vastConfigOrUrlOrFlag;


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/SPLY-47

### Description
1. This utility was mistakenly returning QA tracking domains for Prod VAST solo tags
1. On the VAST solo tags (example: https://get.truex.com/af9cc97d917de89807fa65ed1d8150d818f4340c/vast/solo) the vast config JSON is passed to the choice card as an object with this format: `{AdParameters: <JSON encoded string of Vast Config>}`
    1. See how this is handled when fetching the Vast config: https://github.com/socialvibe/integration_core/blob/develop/src/js/vpaid/modules/txmvpaid.js#L1253-L1255
1. See further debugging details here: https://truex.slack.com/archives/C01D8LX2SE6/p1645126337163759
1. Called by this line in `integration_core`: https://github.com/socialvibe/integration_core/blob/develop/src/js/vpaid/modules/vpaidbase.js#L40 

### Testing
1. Added unit tests
2. Tested VPAID solo tag via https://tools.springserve.com/tagtest + Charles network override to return local copy of `desktop_vpaid.js` including these changes + Chrome network Inspector
   1. Observed QA tracking URLs before change
   1. Observed Prod tracking URLs after change

### TODO
- [ ] Update `integration_core` to point to this change
- [ ] Ensure `integration_core` deploys the VPAID choice card files correctly

### Commit Message Subject(s)
Handle string encoded JSON in VAST config

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

