### PR TITLE
Check vast_config_url for servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.9
+* [CTV-3438](https://truextech.atlassian.net/browse/CTV-3438): handle `/vast` tag payloads for VPAID choice card tracking
+
 ## v1.6.8
 * [CTV-3380](https://truextech.atlassian.net/browse/CTV-3380): HTML5 - Inconsistency in (and lack of definition for) Bluescript string replace operation
     * Use latest babel, core-jss

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -45,6 +45,12 @@ describe("truex_servers testing", () => {
         const demoConfig = {ads: [], "service_url": "measure.truex.com"};
         verifyServers(new TruexServers(demoConfig), true);
 
+        const prodVastConfigUrlConfig = {ads: [], "vast_config_url": "get.truex.com"};
+        verifyServers(new TruexServers(prodVastConfigUrlConfig), true);
+
+        const qaVastConfigUrlConfig = {ads: [], "vast_config_url": "qa-get.truex.com"};
+        verifyServers(new TruexServers(qaVastConfigUrlConfig), false);
+
         function verifyServers(servers, isProd) {
             expect(servers.isProduction).toBe(isProd);
 

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -26,7 +26,7 @@ export class TruexServers {
         } else if (vastConfigOrUrlOrFlag) {
             const vc = vastConfigOrUrlOrFlag;
             const firstAd = vc && vc.ads && vc.ads[0];
-            isProd = isTruexProductionUrl(firstAd && firstAd.window_url || vc.card_creative_url || vc.service_url);
+            isProd = isTruexProductionUrl(firstAd && firstAd.window_url || vc.card_creative_url || vc.service_url || vc.vast_config_url);
         }
 
         this.isProduction = isProd;


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3438

### Description
1. For `/vast` VPAID style tags, the VAST config url is stored under the `vast_config_url` JSON key
2. Ensure we check this key as well when looking for a TrueX url 

### Testing
1. Unit tests
2. Did a Charles rewrite https://media.truex.com/integration/vpaid/desktop_vpaid.js using this change plus change in `integration_core` (PR link to be added)

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

