### PR TITLE
add isAndroidMobile support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.6.9
+* [CTV-3575](https://truextech.atlassian.net/browse/CTV-3575): allow BS video-element to be created from JS code in ads
+    * add android platform detection
+
 ## v1.6.8
 * [CTV-3380](https://truextech.atlassian.net/browse/CTV-3380): HTML5 - Inconsistency in (and lack of definition for) Bluescript string replace operation
     * Use latest babel, core-jss

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.6.9
+## v1.6.10
 * [CTV-3575](https://truextech.atlassian.net/browse/CTV-3575): allow BS video-element to be created from JS code in ads
     * add android platform detection
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -72,6 +72,9 @@ describe("TXMPlatform", () => {
             expect(platform.isUnknown).toBe(false);
             expect(platform.isFireTV).toBe(true);
             expect(platform.isAndroidTV).toBe(false);
+            expect(platform.isAndroidMobile).toBe(false);
+            // we don't consider FireTV to be Android, to avoid confusing it with mobile devices
+            expect(platform.isAndroid).toBe(false);
             expect(platform.isVizio).toBe(false);
             expect(platform.isLG).toBe(false);
             expect(platform.isTizen).toBe(false);
@@ -83,6 +86,8 @@ describe("TXMPlatform", () => {
             expect(platform.version).toBe("5.1.1");
             expect(platform.isCTV).toBe(true);
             expect(platform.isConsole).toBe(false);
+            expect(platform.isHandheld).toBe(false);
+            expect(platform.isTablet).toBe(false);
         });
 
         test("FireTV key mapping", () => {
@@ -100,7 +105,7 @@ describe("TXMPlatform", () => {
             expect(platform.supportsUserAdvertisingId).toBe(true);
         });
 
-        test("test firetv edition modle", () => {
+        test("test firetv edition model", () => {
             const platform = new TXMPlatform("Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12 Build/NS6271; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0");
             expect(platform.isFireTV).toBe(true);
             expect(platform.name).toBe("FireTV");
@@ -111,12 +116,15 @@ describe("TXMPlatform", () => {
     });
 
     describe("Android TV Tests", () => {
-        let platform = new TXMPlatform("Mozilla/5.0 (Linux; Android 5.1.1) Build/LVY48F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0");
+        // Shield TV:
+        let platform = new TXMPlatform("Mozilla/5.0 (Linux; U; Android 5.1; SHIELD Android TV Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.2.582 U3/0.8.0 Mobile Safari/534.30");
 
         test("recognize the AndroidTV platform", () => {
             expect(platform.isUnknown).toBe(false);
             expect(platform.isFireTV).toBe(false);
             expect(platform.isAndroidTV).toBe(true);
+            expect(platform.isAndroid).toBe(true);
+            expect(platform.isAndroidMobile).toBe(false);
             expect(platform.isVizio).toBe(false);
             expect(platform.isLG).toBe(false);
             expect(platform.isTizen).toBe(false);
@@ -124,9 +132,11 @@ describe("TXMPlatform", () => {
             expect(platform.isXboxOne).toBe(false);
             expect(platform.name).toBe("AndroidTV");
             expect(platform.model).toBe(platform.name);
-            expect(platform.version).toBe("5.1.1");
+            expect(platform.version).toBe("5.1");
             expect(platform.isCTV).toBe(true);
             expect(platform.isConsole).toBe(false);
+            expect(platform.isHandheld).toBe(false);
+            expect(platform.isTablet).toBe(false);
         });
 
         test("AndroidTV key mapping", () => {
@@ -137,6 +147,61 @@ describe("TXMPlatform", () => {
             expect(platform.getInputAction(keyCodes.rightArrow)).toBe(inputActions.moveRight);
             expect(platform.getInputAction(keyCodes.enter)).toBe(inputActions.select);
             expect(platform.getInputAction(4)).toBe(inputActions.back);
+        });
+    });
+
+    describe("Android Phone Tests", () => {
+        navigator.maxTouchPoints = 1; // touch support is the key to determine mobile vs TV
+
+        // Nokia example:
+        let platform = new TXMPlatform("Mozilla/5.0 (Linux; U; Android 4.2; ru-ru; Nokia_X Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/E7FBAF");
+
+        test("recognize the Android mobile platform", () => {
+            expect(platform.isUnknown).toBe(false);
+            expect(platform.isFireTV).toBe(false);
+            expect(platform.isAndroidTV).toBe(false);
+            expect(platform.isAndroid).toBe(true);
+            expect(platform.isAndroidMobile).toBe(true);
+            expect(platform.isVizio).toBe(false);
+            expect(platform.isLG).toBe(false);
+            expect(platform.isTizen).toBe(false);
+            expect(platform.isPS4).toBe(false);
+            expect(platform.isXboxOne).toBe(false);
+            expect(platform.name).toBe("Android");
+            expect(platform.model).toBe(platform.name);
+            expect(platform.version).toBe("4.2");
+            expect(platform.isCTV).toBe(false);
+            expect(platform.isConsole).toBe(false);
+            expect(platform.isHandheld).toBe(true);
+            expect(platform.isTablet).toBe(false);
+        });
+    });
+
+
+    describe("Android Tablet Tests", () => {
+        navigator.maxTouchPoints = 1; // touch support is the key to determine mobile vs TV
+
+        // Samsung Galaxy Tablet:
+        let platform = new TXMPlatform("Mozilla/5.0 (Linux; Android 7.1.1; SM-T555 Build/NMF26X; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.96 Safari/537.36");
+
+        test("recognize the Android mobile platform", () => {
+            expect(platform.isUnknown).toBe(false);
+            expect(platform.isFireTV).toBe(false);
+            expect(platform.isAndroidTV).toBe(false);
+            expect(platform.isAndroid).toBe(true);
+            expect(platform.isAndroidMobile).toBe(true);
+            expect(platform.isVizio).toBe(false);
+            expect(platform.isLG).toBe(false);
+            expect(platform.isTizen).toBe(false);
+            expect(platform.isPS4).toBe(false);
+            expect(platform.isXboxOne).toBe(false);
+            expect(platform.name).toBe("Android");
+            expect(platform.model).toBe(platform.name);
+            expect(platform.version).toBe("7.1.1");
+            expect(platform.isCTV).toBe(false);
+            expect(platform.isConsole).toBe(false);
+            expect(platform.isHandheld).toBe(false);
+            expect(platform.isTablet).toBe(true);
         });
     });
 

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -579,6 +579,8 @@ export class TXMPlatform {
         }
 
         function configureForAndroid() {
+            self.model = null; // to be filled in below
+
             configureForAndroidBase();
 
             // Android in the user agent is true for both Android mobile and AndroidTV

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -595,7 +595,7 @@ export class TXMPlatform {
                 self.name = "AndroidTV";
             }
 
-            self.model = self.name;
+            if (!self.model) self.model = self.name;
         }
 
         function configureForAndroidBase() {

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -70,7 +70,6 @@ export class TXMPlatform {
         this.isPS4 = false;
         this.isPS5 = false;
 
-        this.isAndroid = false; // true for both android mobile and android tv
         this.isAndroidMobile = false;
         this.isAndroidTV = false;
         this.isFireTV = false;
@@ -117,6 +116,7 @@ export class TXMPlatform {
         this._configure(userAgent);
     }
 
+    get isAndroid() { return this.isAndroidMobile || this.isAndroidTV }
     get isAndroidOrFireTV() { return this.isAndroidTV || this.isFireTV }
 
     get isHandheld() { return this.isIPhone || this.isAndroidMobile && /Mobile/.test(this.userAgent) }
@@ -585,7 +585,6 @@ export class TXMPlatform {
 
             // Android in the user agent is true for both Android mobile and AndroidTV
             // Note also that we don't consider FireTV to be Android, to avoid confusing it with mobile devices.
-            self.isAndroid = true;
             if (self.supportsTouch) {
                 self.isAndroidMobile = true;
                 self.name = "Android";

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -70,8 +70,10 @@ export class TXMPlatform {
         this.isPS4 = false;
         this.isPS5 = false;
 
-        this.isFireTV = false;
+        this.isAndroid = false; // true for both android mobile and android tv
+        this.isAndroidMobile = false;
         this.isAndroidTV = false;
+        this.isFireTV = false;
 
         this.isXboxOne = false;
         this.isNintendoSwitch = false;
@@ -87,7 +89,7 @@ export class TXMPlatform {
         this.useWindowScroll = true;
 
         this.supportsMouse = false;
-        this.supportsTouch = false;
+        this.supportsTouch = (navigator.maxTouchPoints || 'ontouchstart' in document.documentElement);
 
         this.supportsGyro = false; // on all platforms except perhaps for the Switch?
 
@@ -117,8 +119,8 @@ export class TXMPlatform {
 
     get isAndroidOrFireTV() { return this.isAndroidTV || this.isFireTV }
 
-    get isHandheld() { return this.isIPhone || this.isAndroid && /Mobile/.test(this.userAgent) }
-    get isTablet() { return this.isIPad || this.isAndroid && !this.isHandheld }
+    get isHandheld() { return this.isIPhone || this.isAndroidMobile && /Mobile/.test(this.userAgent) }
+    get isTablet() { return this.isIPad || this.isAndroidMobile && !this.isHandheld }
 
     get isCTV() { return this.isLG || this.isVizio || this.isTizen || this.isAndroidTV || this.isFireTV || this.isComcast }
     get isConsole() { return this.isXboxOne || this.isPS4 || this.isPS5 || this.isNintendoSwitch }
@@ -261,11 +263,10 @@ export class TXMPlatform {
             configureForXboxOne();
 
         } else if (/Android/.test(userAgent)) {
-            // TODO: distinguish between Android mobile and Android TV
             if (/AFT/.test(userAgent)) {
                 configureForFireTV();
             } else {
-                configureForAndroidTV();
+                configureForAndroid();
             }
 
         } else if (/Linux/.test(userAgent) && (window.$badger || !window.localStorage)) {
@@ -577,14 +578,24 @@ export class TXMPlatform {
             }
         }
 
-        function configureForAndroidTV() {
+        function configureForAndroid() {
             configureForAndroidBase();
-            self.isAndroidTV = true;
-            self.name = "AndroidTV";
-            self.model = self.name;
 
-            actionKeyCodes[inputActions.back] = 4;
-            actionKeyCodes[inputActions.menu] = 82;
+            // Android in the user agent is true for both Android mobile and AndroidTV
+            // Note also that we don't consider FireTV to be Android, to avoid confusing it with mobile devices.
+            self.isAndroid = true;
+            if (self.supportsTouch) {
+                self.isAndroidMobile = true;
+                self.name = "Android";
+
+            } else {
+                self.isAndroidTV = true;
+                actionKeyCodes[inputActions.back] = 4;
+                actionKeyCodes[inputActions.menu] = 82;
+                self.name = "AndroidTV";
+            }
+
+            self.model = self.name;
         }
 
         function configureForAndroidBase() {
@@ -612,15 +623,9 @@ export class TXMPlatform {
                 self.model = details[1];
                 self.version = details[2];
             } else {
-                var groupStart = userAgent.indexOf("(");
-                if (groupStart >= 0) {
-                    var groupEnd = userAgent.indexOf(")", groupStart);
-                    if (groupEnd < 0) groupEnd = userAgent.length;
-                    var detailSubstring = userAgent.substring(groupStart+1, groupEnd);
-                    var detailSplit = detailSubstring.split(";");
-                    self.model = detailSplit[1].trim();
-                    const versionParts = detailSplit[1].split(" ");
-                    self.version = versionParts[versionParts.length - 1];
+                var match = userAgent.match(/Android ([0-9](\.[0-9])*)/);
+                if (match) {
+                    self.version = match[1];
                 }
             }
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3575

### Description
* expose TXM.layout.createVideElement
* ensure can run in JS-only ads
* added android mobile detection
* some click for sound fixes

### Testing
* See QA notes in ticket.

### Commit Message Subject
CTV-3575: allow BS video-element to be created from JS code in ads

### Additional Context

### Related PRs
shared: https://github.com/socialvibe/truex-shared-js/pull/66
bluescript: https://github.com/socialvibe/truex-bluescript-js/pull/82
C3: https://github.com/socialvibe/container_core/pull/529
IC: https://github.com/socialvibe/integration_core/pull/303
TAR: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/108
Skyline: https://github.com/socialvibe/Skyline/pull/279
firetv-webview: https://github.com/socialvibe/firetv-webview-webapp/pull/61

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

