### PR TITLE
Bugfix/ctv 3650 skyline deployment does not upload to skyline.truex.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.6.13
+* [CTV-3650](https://infillion.atlassian.net/browse/CTV-3650): skyline deployment does not upload to skyline.truex.com
+
 ## v1.6.12
 * [CTV-3647](https://infillion.atlassian.net/browse/CTV-3647): reduce verbosity  of S3 error logging
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/deploy/s3-upload.js
+++ b/src/deploy/s3-upload.js
@@ -105,12 +105,10 @@ module.exports = {
             params.Expires = 0;
         }
 
-        const callback = (err, data) => {
-            if (err) {
+        return util.promisify(s3Client.putObject.bind(s3Client))(params)
+            .catch(err => {
                 console.error(`s3 upload of ${bucket}/${key} failed, error: ${err}`);
                 throw err;
-            }
-        }
-        return util.promisify(s3Client.putObject.bind(s3Client))(params, callback);
+            });
     },
 };

--- a/src/deploy/s3-upload.js
+++ b/src/deploy/s3-upload.js
@@ -107,7 +107,7 @@ module.exports = {
 
         return util.promisify(s3Client.putObject.bind(s3Client))(params)
             .catch(err => {
-                console.error(`s3 upload of ${bucket}/${key} failed, error: ${err}`);
+                console.error(`s3 upload failed for ${bucket}/${key}\n  error: ${err}`);
                 throw err;
             });
     },


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3650

### Description
* Ensure skyline deployment uploads to skyline.truex.com

### Testing
* Unit tests

### Commit Message Subject
CTV-3650: skyline deployment does not upload to skyline.truex.com

### Additional Context

### Related PRs
shared: https://github.com/socialvibe/truex-shared-js/pull/70
bluescript: https://github.com/socialvibe/truex-bluescript-js/pull/85
C3: https://github.com/socialvibe/container_core/pull/537
IC: https://github.com/socialvibe/integration_core/pull/306
TAR: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/110
Skyline: https://github.com/socialvibe/Skyline/pull/282/files
firetv-webview: https://github.com/socialvibe/firetv-webview-webapp/pull/62

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

