### PR TITLE
Bugfix/ctv 3131 skyline automation sometimes exits test control tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.7.2
+* [CTV-3131](https://infillion.atlassian.net/browse/CTV-3131): Skyline automation sometimes exits Test Control tab after running a test
+
 ## v1.6.13
 * [CTV-3650](https://infillion.atlassian.net/browse/CTV-3650): skyline deployment does not upload to skyline.truex.com
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.6.13",
+  "version": "1.7.2",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -184,23 +184,21 @@ export class TXMFocusManager {
         if (!this._isBlockingBackActions) return;
         this._isBlockingBackActions = false;
 
-        var state = history.state;
         window.removeEventListener("popstate", this.onPopState);
 
-        setTimeout(() => {
-            // Ensure no back action blocks are present from this focus manager.
-            if (state && state.forTruex && state.focusManager == this.id && state.backActionStub) {
-                history.go(-2); // remove stub and block
-                this.debugLog('restoreBackActions: remove stub and block');
+        // Ensure no back action blocks are present from this focus manager.
+        var state = history.state;
+        if (state && state.forTruex && state.focusManager == this.id && state.backActionStub) {
+            this.debugLog('restoreBackActions: remove stub and block');
+            history.go(-2); // remove stub and block
 
-            } else if (state && state.forTruex && state.focusManager == this.id && state.backActionBlock) {
-                history.back(); // remove block
-                this.debugLog('restoreBackActions: remove block');
+        } else if (state && state.forTruex && state.focusManager == this.id && state.backActionBlock) {
+            this.debugLog('restoreBackActions: remove block');
+            history.back(); // remove block
 
-            } else {
-                this.debugLog('restoreBackActions: nothing removed');
-            }
-        }, 0);
+        } else {
+            this.debugLog('restoreBackActions: nothing removed');
+        }
     }
 
     /**


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-3131

### Description
* FireTV builds were getting stuck on home page again.

### Testing
* From local test script stub in Chrome and FireTV stick.
* Will need to do a regression pass on all devices, especially the PS4, PS5, Comcast devices

### Commit Message Subject
CTV-3131: Skyline automation sometimes exits Test Control tab after running a test

### Additional Context

### Related PRs
shared: https://github.com/socialvibe/truex-shared-js/pull/72
bluescript: https://github.com/socialvibe/truex-bluescript-js/pull/86
C3: https://github.com/socialvibe/container_core/pull/540
IC: https://github.com/socialvibe/integration_core/pull/307
TAR: https://github.com/socialvibe/TruexAdRenderer-HTML5/pull/111
Skyline: https://github.com/socialvibe/Skyline/pull/285

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

