### PR TITLE
Add (XF-15): add Xtended View support to HTML5 CTVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.7.11
+* [XF-15](https://infillion.atlassian.net/browse/XF-15): Add ad event for xtended view
+
 ## v1.7.10
 * [CTV-3359](https://infillion.atlassian.net/browse/CTV-3359): Support Jenkins UAT automation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/events/txm_ad_events.js
+++ b/src/events/txm_ad_events.js
@@ -12,6 +12,7 @@ const adEvents = {
     skipCardShown: 'skipCardShown',
     userCancel: 'userCancel',
     videoEvent: 'videoEvent',
+    xtendedViewStarted: 'xtendedViewStarted',
 };
 
 export { adEvents };


### PR DESCRIPTION
### JIRA
https://infillion.atlassian.net/browse/XF-15

### Description
Adding an additional (optional) ad event for xtended view

### Testing
n/a

### Commit Message Subject(s)
LIST_PROPOSED_COMMIT_SUBJECT_LINES

### Additional Context
OPTIONAL_ADDITIONAL_INFO

### Related PRs
Also, see
Share: https://github.com/socialvibe/truex-shared-js/pull/74/
C3:https://github.com/socialvibe/container_core/pull/551/
IC: https://github.com/socialvibe/integration_core/pull/319
Skyline: https://github.com/socialvibe/Skyline/pull/299
TAR-Android: https://github.com/socialvibe/TruexAdRenderer-Android/pull/104

### Checks
- [ ] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [ ] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

