### PR TITLE
CTV-3233 | HTML5: auto-repeat back key escapes out of AYS dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.7.12
+* [CTV-3233](https://infillion.atlassian.net/browse/CTV-3233): Stopping held buttons from propagating to parent focusmanagers
+
 ## v1.7.11
 * [XF-15](https://infillion.atlassian.net/browse/XF-15): Add ad event for xtended view
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.7.13
+* Version Increment
+
 ## v1.7.12
 * [CTV-3233](https://infillion.atlassian.net/browse/CTV-3233): Stopping held buttons from propagating to parent focusmanagers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Changelog
 
-## v1.7.13
-* Version Increment
-
-## v1.7.12
+## v1.7.14
 * [CTV-3233](https://infillion.atlassian.net/browse/CTV-3233): Stopping held buttons from propagating to parent focusmanagers
 
 ## v1.7.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.7.14
+## v1.7.15
 * [CTV-3233](https://infillion.atlassian.net/browse/CTV-3233): Stopping held buttons from propagating to parent focusmanagers
 
 ## v1.7.11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.11",
+  "version": "1.7.13",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/focus_manager/txm_focus_manager.js
+++ b/src/focus_manager/txm_focus_manager.js
@@ -263,8 +263,11 @@ export class TXMFocusManager {
             const now = Date.now();
             const elapsedTime = now - this._lastKeyEventTimestamp;
             if (keyCode == this._lastKeyCode && elapsedTime <= throttleDelay) {
-                // Swallow the excess key event.
-                return true; // handled
+                // Swallow the excess key event and prevent it from propagating to parent's focusManager
+                event.preventDefault();
+                event.stopPropagation();
+                event.stopImmediatePropagation();
+                return false; // handled
             }
             this._lastKeyCode = keyCode;
             this._lastKeyEventTimestamp = now;


### PR DESCRIPTION
### JIRA
[CTV-3233](https://infillion.atlassian.net/browse/CTV-3233): Stopping held buttons from propagating to parent focusmanagers

### Description
* Changed throttling logic that when stopping held buttons, prevent it from propagating to parent focus_managers.
___
* On holding Backspace, when a throttle happened, it was not stopping the onKeyDown from propogating to the parent's focus_manager. AYS's onKeyDown propagated to the ChoiceCard's focus_manager's onKeyDown, running the non-throttled flow, and fired ChoiceCard's onInputAction->onBackAction-> closing the ad.
* Similarly, if there were multiple components on the ad that could've been navigated by directional controls, while AYS screen dialog is showing, holding a direction key will cause the focus to move in the ad that is not suppose to be in focus at the time.

### Testing
* Held buttons and observed behaviour on AYS and its parents in various ads available on skyline.
* Held buttons and observed behaviour of the change when AYS is not showing, in various ads available on skyline.

### Commit Message Subject(s)
LIST_PROPOSED_COMMIT_SUBJECT_LINES

### Additional Context
OPTIONAL_ADDITIONAL_INFO

### Related PRs
OPTIONAL_ADD_PR_LINKS

### Checks
- [ ] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [ ] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

