### PR TITLE
Task/pi 2297/invalidate fastly cache support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ branches:
 before_script:
   - yarn cache clean
   - yarn install
+  - npx browserslist@latest --update-db
 script:
   - npm run test
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.7.16
+* [PI-2297](https://infillion.atlassian.net/browse/PI-2297): Update deployment scripts to flush Fastly CDN caches
+
 ## v1.7.15
 * [CTV-3233](https://infillion.atlassian.net/browse/CTV-3233): Stopping held buttons from propagating to parent focusmanagers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.7.16
+## v1.7.17
 * [PI-2297](https://infillion.atlassian.net/browse/PI-2297): Update deployment scripts to flush Fastly CDN caches
 
 ## v1.7.15

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.16",
+  "version": "1.7.17",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   ],
   "main": "./src/",
   "scripts": {
-    "test": "jest",
+    "browserslist-update": "npx browserslist@latest --update-db",
+    "test": "npm run browserslist-update && jest",
     "watch": "jest --watch",
     "coverage": "jest --coverage"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.15",
+  "version": "1.7.16",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   ],
   "main": "./src/",
   "scripts": {
-    "browserslist-update": "npx browserslist@latest --update-db",
-    "test": "npm run browserslist-update && jest",
+    "test": "jest",
     "watch": "jest --watch",
     "coverage": "jest --coverage"
   },

--- a/src/deploy/__tests__/fastly-tests.js
+++ b/src/deploy/__tests__/fastly-tests.js
@@ -10,9 +10,7 @@ describe("fastly tests", () => {
     }
 
     test('test purgeFastlyFile', () => {
-        return Promise.all([
-            purgeFastlyUrl('https://qa-media.truex.com/container/3.x/current/ctv.html', apiToken),
-            purgeFastlyUrl('https://media.truex.com/container/3.x/current/ctv.html', apiToken)
-            ]);
+        return purgeFastlyUrl('https://qa-media.truex.com/container/3.x/current/ctv.html', apiToken)
+            .then(() => purgeFastlyUrl('https://media.truex.com/container/3.x/current/ctv.html', apiToken));
     });
 });

--- a/src/deploy/__tests__/fastly-tests.js
+++ b/src/deploy/__tests__/fastly-tests.js
@@ -1,4 +1,4 @@
-const { purgeFastlyFile } = require('../purge-fastly-service');
+const { purgeFastlyUrl } = require('../purge-fastly-service');
 
 describe("fastly tests", () => {
     const apiToken = process.env.FASTLY_API_TOKEN;
@@ -11,8 +11,8 @@ describe("fastly tests", () => {
 
     test('test purgeFastlyFile', () => {
         return Promise.all([
-            purgeFastlyFile('https://qa-media.truex.com/container/3.x/current/ctv.html', apiToken),
-            purgeFastlyFile('https://media.truex.com/container/3.x/current/ctv.html', apiToken)
+            purgeFastlyUrl('https://qa-media.truex.com/container/3.x/current/ctv.html', apiToken),
+            purgeFastlyUrl('https://media.truex.com/container/3.x/current/ctv.html', apiToken)
             ]);
     });
 });

--- a/src/deploy/__tests__/fastly-tests.js
+++ b/src/deploy/__tests__/fastly-tests.js
@@ -1,0 +1,18 @@
+const { purgeFastlyFile } = require('../purge-fastly-service');
+
+describe("fastly tests", () => {
+    const apiToken = process.env.FASTLY_API_TOKEN;
+    if (!apiToken) {
+        test("fastly tests skipped", () => {
+            console.warn('fastly tests skipped due to missing FASTLY_API_TOKEN value');
+        });
+        return;
+    }
+
+    test('test purgeFastlyFile', () => {
+        return Promise.all([
+            purgeFastlyFile('https://qa-media.truex.com/container/3.x/current/ctv.html', apiToken),
+            purgeFastlyFile('https://media.truex.com/container/3.x/current/ctv.html', apiToken)
+            ]);
+    });
+});

--- a/src/deploy/edgecast-purge-bucket.js
+++ b/src/deploy/edgecast-purge-bucket.js
@@ -1,6 +1,9 @@
 const p = require("path");
 const Edgecast = require("edgecast-purge");
 
+// This is no longer needed in practice, as we have migrated away from Edgecast, and are now using Fastly CDN.
+// It remains here for reference purposes.
+
 module.exports = (bucket, path, edgeCastToken, edgeCastCustomerId) => {
     const edgecastService = new Edgecast(edgeCastToken, edgeCastCustomerId);
     const pathsToPurge = [];

--- a/src/deploy/increment-cachebuster.js
+++ b/src/deploy/increment-cachebuster.js
@@ -1,6 +1,10 @@
 const path = require("path");
 const fetch = require('node-fetch');
 
+// Helper to ensure that served ads have an incremented "cache buster" counter value in their urls.
+// This was put in place to work around unreliable cache purging previously encounted with Edgecast CDN.
+// NOTE: this helper is no longer needed in practice, remains here for reference purposes.
+
 module.exports = (env) => {
     const environment = env === "prod" ? "" : "qa-";
     const hostname = `${environment}dimsum.truex.com`;

--- a/src/deploy/purge-fastly-service.js
+++ b/src/deploy/purge-fastly-service.js
@@ -7,6 +7,12 @@ function invokeFastlyApi(path, apiToken) {
         headers: {
             "Fastly-Key": apiToken
         }
+    }).then(resp => {
+        if (resp.ok) return;
+        const statusMsg = resp.status + (resp.statusText ? ' - ' + resp.statusText : '');
+        const errMsg = `fastly action failed: ${statusMsg}\nfor ${path}`;
+        console.error(errMsg);
+        throw new Error(errMsg);
     });
 }
 

--- a/src/deploy/purge-fastly-service.js
+++ b/src/deploy/purge-fastly-service.js
@@ -19,7 +19,7 @@ function invokeFastlyApi(path, apiToken) {
 }
 
 function purgeFastlyUrl(url, apiToken) {
-    if (url) url = url.replace(/^[a-zA-Z]+:\/\//g, ''); // strip protocol
+    if (url) url = url.replace(/^[a-zA-Z]+:\/\//, ''); // strip protocol
     console.log('fastly cache purge: ' + url);
     return invokeFastlyApi('/purge/' + url, apiToken);
 }

--- a/src/deploy/purge-fastly-service.js
+++ b/src/deploy/purge-fastly-service.js
@@ -1,0 +1,26 @@
+const fetch = require('node-fetch');
+
+function invokeFastlyApi(path, apiToken) {
+    if (path.startsWith('/')) path = path.substring(1);
+    return fetch(`https://api.fastly.com/${path}`, {
+        method: 'POST',
+        headers: {
+            "Fastly-Key": apiToken
+        }
+    });
+}
+
+function purgeFastlyUrl(url, apiToken) {
+    console.log('fastly cache purge: ' + url);
+    return invokeFastlyApi('/purge/' + url, apiToken);
+}
+
+function purgeFastlyService(serviceId, apiToken) {
+    console.log('fastly cache service purge: ' + serviceId);
+    return invokeFastlyApi(`/service/${serviceId}/purge_all`, apiToken);
+}
+
+module.exports = {
+    purgeFastlyUrl,
+    purgeFastlyService
+};

--- a/src/deploy/purge-fastly-service.js
+++ b/src/deploy/purge-fastly-service.js
@@ -18,6 +18,7 @@ function invokeFastlyApi(path, apiToken) {
 
 function purgeFastlyUrl(url, apiToken) {
     console.log('fastly cache purge: ' + url);
+    if (!apiToken) throw new Error('missing fastly api token');
     return invokeFastlyApi('/purge/' + url, apiToken);
 }
 

--- a/src/deploy/purge-fastly-service.js
+++ b/src/deploy/purge-fastly-service.js
@@ -19,7 +19,7 @@ function invokeFastlyApi(path, apiToken) {
 }
 
 function purgeFastlyUrl(url, apiToken) {
-    if (url) url = url.replaceAll(/^[a-zA-Z]+:/, ''); // strip protocol
+    if (url) url = url.replace(/^[a-zA-Z]+:\/\//g, ''); // strip protocol
     console.log('fastly cache purge: ' + url);
     return invokeFastlyApi('/purge/' + url, apiToken);
 }

--- a/src/deploy/purge-fastly-service.js
+++ b/src/deploy/purge-fastly-service.js
@@ -1,6 +1,8 @@
 const fetch = require('node-fetch');
 
 function invokeFastlyApi(path, apiToken) {
+    if (!path) throw new Error('missing fastly api path: ' + path);
+    if (!apiToken) throw new Error('missing fastly api token for: ' + path);
     if (path.startsWith('/')) path = path.substring(1);
     return fetch(`https://api.fastly.com/${path}`, {
         method: 'POST',
@@ -17,8 +19,8 @@ function invokeFastlyApi(path, apiToken) {
 }
 
 function purgeFastlyUrl(url, apiToken) {
+    if (url) url = url.replaceAll(/^[a-zA-Z]+:/, ''); // strip protocol
     console.log('fastly cache purge: ' + url);
-    if (!apiToken) throw new Error('missing fastly api token');
     return invokeFastlyApi('/purge/' + url, apiToken);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,9 +1651,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001302"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001302.tgz#da57ce61c51177ef3661eeed7faef392d3790aaa"
-  integrity sha512-YYTMO+tfwvgUN+1ZnRViE53Ma1S/oETg+J2lISsqi/ZTNThj3ZYBOKP2rHwJc37oCsPqAzJ3w2puZHn0xlLPPw==
+  version "1.0.30001473"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz"
+  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### JIRA
* [PI-2297](https://infillion.atlassian.net/browse/PI-2297): Update deployment scripts to flush Fastly CDN caches

### Description
* provide purseFastlyUrl to support Fastly cache invalidation during truex deployments

### Testing
* unit tests
* feature branch uploads in other repos

### Commit Message Subject(s)
n/a

### Additional Context
n/a

### Related PRs
n/a

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [ ] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)



[PI-2297]: https://infillion.atlassian.net/browse/PI-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ