### PR TITLE
Fix/pi 2316/set cache control header on all uploaded files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ before_script:
   - yarn cache clean
   - yarn install
   - npx browserslist@latest --update-db
+  - pip install --user awscli
+  - export PATH=$PATH:$HOME/.local/bin
+  - eval $(aws ecr get-login --no-include-email --region us-east-1)
 script:
   - npm run test
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ before_script:
   - yarn cache clean
   - yarn install
   - npx browserslist@latest --update-db
-  - pip install --user awscli
-  - export PATH=$PATH:$HOME/.local/bin
-  - eval $(aws ecr get-login --no-include-email --region us-east-1)
 script:
   - npm run test
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.7.18
+* [PI-2316](https://infillion.atlassian.net/browse/PI-2316): set cache-control header on all uploaded files
+
 ## v1.7.17
 * [PI-2297](https://infillion.atlassian.net/browse/PI-2297): Update deployment scripts to flush Fastly CDN caches
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -145,9 +145,9 @@ module.exports = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  testMatch: [
-    "**/__tests__/**/*.[jt]s?(x)"
-  ],
+  // testMatch: [
+  //   "**/__tests__/**/*.js"
+  // ],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   testPathIgnorePatterns: [
@@ -155,7 +155,7 @@ module.exports = {
   ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
-  // testRegex: ["-test.js"],
+  testRegex: ["__tests__/[^/]+-tests?.js"],
 
   // This option allows the use of a custom results processor
   // testResultsProcessor: null,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@babel/runtime": "^7.4.1",
     "babel-jest": "^25.1.0",
     "core-js": "3",
-    "jest": "^24.0.0"
+    "jest": "^24.0.0",
+    "whatwg-fetch": "^3.0.0"
   },
   "dependencies": {
     "aws-sdk": "^2.260.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.17",
+  "version": "1.7.18",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/deploy/__tests__/audio_stub.mp3
+++ b/src/deploy/__tests__/audio_stub.mp3
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/__tests__/font-stub.ttf
+++ b/src/deploy/__tests__/font-stub.ttf
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/__tests__/html-stub.html
+++ b/src/deploy/__tests__/html-stub.html
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/__tests__/image_stub.png
+++ b/src/deploy/__tests__/image_stub.png
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/__tests__/js-stub.js
+++ b/src/deploy/__tests__/js-stub.js
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/__tests__/upload-tests.js
+++ b/src/deploy/__tests__/upload-tests.js
@@ -1,34 +1,51 @@
 const { purgeFastlyUrl } = require('../purge-fastly-service');
 const s3 = require("../s3-upload");
+const { getContentType, getContentCacheControl } = require("../content-type");
 const uploadDist = require("../upload-dist");
 const path = require('path');
 
 describe("s3 upload tests", () => {
-    const apiToken = process.env.FASTLY_API_TOKEN;
-    if (!apiToken) {
-        test("upload tests skipped", () => {
-            console.warn('upload tests skipped due to missing FASTLY_API_TOKEN value');
-        });
-        return;
+    function expectedCacheControl(filePath) {
+        // @TODO: ensure the expected cache-control results are actually correct.
+        switch (path.extname(filePath).toLowerCase()) {
+            case '.html': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+            case '.js': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+            case '.json': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+            case '.ttf': return 'max-age=604800 s-maxage=31536000 stale-while-revalidate=300';
+            case '.jpg':
+            case '.png': return 'max-age=86400 s-maxage=2592000 stale-while-revalidate=300';
+            case '.mp4': return 'max-age=604800 s-maxage=10368000 stale-while-revalidate=300';
+            case '.mp3': return 'max-age=604800 s-maxage=10368000 stale-while-revalidate=300';
+            default: throw new Error('unknown extension: ' + filePath);
+        }
     }
 
+    test("cache control tests", () => {
+        function testFile(filePath) {
+            const expectedCC = expectedCacheControl(filePath);
+            const contentType = getContentType(filePath);
+            const defaultCC = getContentCacheControl(contentType);
+            expect(defaultCC).toBe(expectedCC);
+        }
+
+        testFile('html_stub.html');
+        testFile('js_stub.js');
+        testFile('data_stub.json');
+        testFile('image_stub.png');
+        testFile('image_stub.jpg');
+        testFile('font_stub.ttf');
+        testFile('audio_stub.mp3');
+        testFile('video_stub.mp4');
+    });
+
     test('test S3 upload with fastly cache control', () => {
+        if (!process.env.FASTLY_API_TOKEN || !process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+            console.warn('test skipped due to missing AWS_ACCESS_* or FASTLY_API_TOKEN env values');
+            return;
+        }
+
         const bucket = "qa-media.truex.com";
         const bucketPath = "truex-shared/__tests__";
-
-        function expectedCacheControl(fileUrl) {
-            switch (path.extname(fileUrl).toLowerCase()) {
-                case '.html': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                case '.js': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                case '.json': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                case '.png': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                case '.ttf': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                case '.png': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                case '.mp4': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                case '.mp3': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-                default: throw new Error('unknown extension: ' + fileUrl);
-            }
-        }
 
         return s3.cleanFolder(bucket, bucketPath + '/').then(() => {
             return uploadDist(bucket, bucketPath, './src/deploy/__tests__/', {}, (filePath, fileUrl) => {

--- a/src/deploy/__tests__/upload-tests.js
+++ b/src/deploy/__tests__/upload-tests.js
@@ -1,0 +1,44 @@
+const { purgeFastlyUrl } = require('../purge-fastly-service');
+const s3 = require("../s3-upload");
+const uploadDist = require("../upload-dist");
+const path = require('path');
+
+describe("s3 upload tests", () => {
+    const apiToken = process.env.FASTLY_API_TOKEN;
+    if (!apiToken) {
+        test("upload tests skipped", () => {
+            console.warn('upload tests skipped due to missing FASTLY_API_TOKEN value');
+        });
+        return;
+    }
+
+    test('test S3 upload with fastly cache control', () => {
+        const bucket = "qa-media.truex.com";
+        const bucketPath = "truex-shared/__tests__";
+
+        function expectedCacheControl(fileUrl) {
+            switch (path.extname(fileUrl).toLowerCase()) {
+                case '.html': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                case '.js': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                case '.json': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                case '.png': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                case '.ttf': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                case '.png': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                case '.mp4': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                case '.mp3': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
+                default: throw new Error('unknown extension: ' + fileUrl);
+            }
+        }
+
+        return s3.cleanFolder(bucket, bucketPath + '/').then(() => {
+            return uploadDist(bucket, bucketPath, './src/deploy/__tests__/', {}, (filePath, fileUrl) => {
+                return purgeFastlyUrl(fileUrl, process.env.FASTLY_API_TOKEN).then(() => {
+                    return fetch(fileUrl).then(resp => {
+                        if (!resp.ok) throw new Error('could not fetch: ' + fileUrl);
+                        expect(resp.headers.cacheControl).toBe(expectedCacheControl(fileUrl));
+                    });
+                });
+            });
+        });
+    });
+});

--- a/src/deploy/__tests__/upload-tests.js
+++ b/src/deploy/__tests__/upload-tests.js
@@ -7,7 +7,6 @@ require('whatwg-fetch');
 
 describe("s3 upload tests", () => {
     function expectedCacheControl(filePath) {
-        // @TODO: ensure the expected cache-control results are actually correct.
         switch (path.extname(filePath).toLowerCase()) {
             case '.html': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
             case '.js': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';

--- a/src/deploy/__tests__/video_stub.mp4
+++ b/src/deploy/__tests__/video_stub.mp4
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/content-type.js
+++ b/src/deploy/content-type.js
@@ -1,62 +1,118 @@
 const path = require('path');
 
-/**
- * getContentType
- * Given a filepath, getContentType returns the mime-type associated to the content
- *
- * @param {string} - filepath
- */
-module.exports = (filePath) => {
-    switch (path.extname(filePath).toLowerCase()) {
-        // Images
-        case '.png': return 'image/png';
-        case '.gif': return 'image/gif';
-        case '.jpg':
-        case '.jpeg':
-            return 'image/jpeg';
-        case '.svg': return 'image/svg+xml';
+module.exports = {
+    /**
+     * getContentType
+     * Given a filepath, getContentType returns the mime-type associated to the content
+     *
+     * @param {string} - filepath
+     */
+    getContentType: (filePath) => {
+        switch (path.extname(filePath).toLowerCase()) {
+            // Images
+            case '.png':
+                return 'image/png';
+            case '.gif':
+                return 'image/gif';
+            case '.jpg':
+            case '.jpeg':
+                return 'image/jpeg';
+            case '.ico':
+                return 'image/vnd.microsoft.icon';
+            case '.svg':
+                return 'image/svg+xml';
 
-        // Web content
-        case '.html': return 'text/html';
-        case '.css': return 'text/css';
-        case '.js': return 'text/javascript';
+            // Web content
+            case '.html':
+                return 'text/html';
+            case '.css':
+                return 'text/css';
+            case '.js':
+                return 'text/javascript';
 
-        // Fonts
-        case '.oft': return 'font/oft';
-        case '.ttf': return 'font/ttf';
-        case '.wof': return 'font/wof';
-        case '.wof2': return 'font/wof2';
+            // Fonts
+            case '.oft':
+                return 'font/oft';
+            case '.ttf':
+                return 'font/ttf';
+            case '.wof':
+                return 'font/wof';
+            case '.wof2':
+                return 'font/wof2';
 
-        // Video
-        case '.avi': return 'video/avi';
-        case '.m4s':
-        case '.mp4':
-            return 'video/mp4';
-        case '.mpeg': return 'video/mpeg';
-        case '.ogv': return 'video/ogg';
-        case '.ts': return 'video/mpt2';
-        case '.webm': return 'video/webm';
-        case '.3gp': return 'video/3gp';
-        case '.3gp2': return 'video/3gp2';
+            // Video
+            case '.avi':
+                return 'video/avi';
+            case '.m4s':
+            case '.mp4':
+                return 'video/mp4';
+            case '.mpeg':
+                return 'video/mpeg';
+            case '.ogv':
+                return 'video/ogg';
+            case '.ts':
+                return 'video/mpt2';
+            case '.webm':
+                return 'video/webm';
+            case '.3gp':
+                return 'video/3gp';
+            case '.3gp2':
+                return 'video/3gp2';
 
-        // Adaptive bit rate video containers:
-        case '.m3u8': return 'application/x-mpegURL';
-        case '.mpd': return 'application/dash+xml';
+            // Adaptive bit rate video containers:
+            case '.m3u8':
+                return 'application/x-mpegURL';
+            case '.mpd':
+                return 'application/dash+xml';
 
-        // Audio
-        case '.acc': return 'audio/acc';
-        case '.avi': return 'audio/avi';
-        case '.mid':
-        case '.midi':
-            return 'audio/midi';
-        case '.mp3': return 'audio/mpeg';
-        case '.m4a': return 'audio/mp4';
-        case '.oga': return 'audio/ogg';
-        case '.opus': return 'audio/opus';
-        case '.wav': return 'audio/wav';
-        case '.webm': return 'audio/webm';
+            // Audio
+            case '.acc':
+                return 'audio/acc';
+            case '.avi':
+                return 'audio/avi';
+            case '.mid':
+            case '.midi':
+                return 'audio/midi';
+            case '.mp3':
+                return 'audio/mpeg';
+            case '.m4a':
+                return 'audio/mp4';
+            case '.oga':
+                return 'audio/ogg';
+            case '.opus':
+                return 'audio/opus';
+            case '.wav':
+                return 'audio/wav';
+            case '.webm':
+                return 'audio/webm';
 
-        // Assume JSON data
-        default: return 'application/json';
+            // Assume JSON data
+            default:
+                return 'application/json';
+        }
+    },
+
+    getContentCacheControl: (contentType) => {
+        const sec = 1;
+        const min = 60 * sec;
+        const hour = 60 * min;
+        const day = 24 * hour;
+        let localMaxAge = 2 * min; // short local caching so we soon enough hit the CDN again
+        let serverMaxAge = day; // anything reasonable, purges should reset CDN caches anyway
+        if (contentType.startsWith('font/')) {
+            // Fonts rarely change.
+            localMaxAge = 7 * day;
+            serverMaxAge = 365 * day;
+        } else if (contentType.startsWith('audio/')
+            || contentType.startsWith('video/')) {
+            // media assets are usually stable.
+            localMaxAge = 7 * day;
+            serverMaxAge = 120 * day;
+        } else if (contentType.startsWith('image/')) {
+            // images are reasonably stable.
+            localMaxAge = 1 * day;
+            serverMaxAge = 30 * day;
+        }
+        return `max-age=${localMaxAge} s-maxage=${serverMaxAge} stale-while-revalidate=${5 * min}`;
     }
 };

--- a/src/deploy/content-type.js
+++ b/src/deploy/content-type.js
@@ -8,22 +8,55 @@ const path = require('path');
  */
 module.exports = (filePath) => {
     switch (path.extname(filePath).toLowerCase()) {
-        case '.html':
-            return 'text/html';
-        case '.png':
-            return 'image/png';
-        case '.gif':
-            return 'image/gif';
+        // Images
+        case '.png': return 'image/png';
+        case '.gif': return 'image/gif';
         case '.jpg':
         case '.jpeg':
             return 'image/jpeg';
-        case '.svg':
-            return 'image/svg+xml';
-        case '.css':
-            return 'text/css';
-        case '.js':
-            return 'text/javascript';
-        default:
-            return 'application/json';
+        case '.svg': return 'image/svg+xml';
+
+        // Web content
+        case '.html': return 'text/html';
+        case '.css': return 'text/css';
+        case '.js': return 'text/javascript';
+
+        // Fonts
+        case '.oft': return 'font/oft';
+        case '.ttf': return 'font/ttf';
+        case '.wof': return 'font/wof';
+        case '.wof2': return 'font/wof2';
+
+        // Video
+        case '.avi': return 'video/avi';
+        case '.m4s':
+        case '.mp4':
+            return 'video/mp4';
+        case '.mpeg': return 'video/mpeg';
+        case '.ogv': return 'video/ogg';
+        case '.ts': return 'video/mpt2';
+        case '.webm': return 'video/webm';
+        case '.3gp': return 'video/3gp';
+        case '.3gp2': return 'video/3gp2';
+
+        // Adaptive bit rate video containers:
+        case '.m3u8': return 'application/x-mpegURL';
+        case '.mpd': return 'application/dash+xml';
+
+        // Audio
+        case '.acc': return 'audio/acc';
+        case '.avi': return 'audio/avi';
+        case '.mid':
+        case '.midi':
+            return 'audio/midi';
+        case '.mp3': return 'audio/mpeg';
+        case '.m4a': return 'audio/mp4';
+        case '.oga': return 'audio/ogg';
+        case '.opus': return 'audio/opus';
+        case '.wav': return 'audio/wav';
+        case '.webm': return 'audio/webm';
+
+        // Assume JSON data
+        default: return 'application/json';
     }
 };

--- a/src/deploy/s3-upload.js
+++ b/src/deploy/s3-upload.js
@@ -123,10 +123,15 @@ module.exports = {
                 // Rarely changes.
                 localMaxAge = 7 * day;
                 serverMaxAge = 365 * day;
-            } else if (contentType.startsWith('audio/') || contentType.startsWith('video/')) {
+            } else if (contentType.startsWith('audio/')
+                || contentType.startsWith('video/')) {
                 // media assets are usually stable.
                 localMaxAge = 7 * day;
                 serverMaxAge = 120 * day;
+            } else if (contentType.startsWith('image/')) {
+                // images are reasonably stable.
+                localMaxAge = 1 * day;
+                serverMaxAge = 30 * day;
             }
             params.CacheControl = `max-age=${localMaxAge} s-maxage=${serverMaxAge} stale-while-revalidate=${5 * min}`;
         }

--- a/src/deploy/s3-upload.js
+++ b/src/deploy/s3-upload.js
@@ -1,5 +1,6 @@
 const util = require('util');
 const AWS = require('aws-sdk');
+const getContentType = require("./content-type");
 
 /**
  * getClient
@@ -85,12 +86,18 @@ module.exports = {
      * @param {string} key
      * @param body
      * @param {string} contentType
-     * @param {string} acl (default='private')
-     * @param config
+     * @param {string} acl 'private' (default), 'public-read', etc.
+     * @param {Object} config options for S3 configuration for the file:
+     * @param {config.cacheControl} Defaults to modest caching based on the type that allows for CDN updates.
+     * @param {config.disableCache} Sets the cache-control to specify no caching should be done
      * @returns {promise}
      */
-    uploadFile: function(bucket, key, body, contentType, acl = 'private', config) {
+    uploadFile: function(bucket, key, body, contentType, acl = 'private', config = {}) {
         const s3Client = getClient();
+
+        if (!contentType) {
+            contentType = getContentType(key);
+        }
 
         const params = {
             Bucket: bucket,
@@ -100,9 +107,28 @@ module.exports = {
             ContentType: contentType
         };
 
-        if (config && config.disableCache === true) {
+        if (config.disableCache) {
             params.CacheControl = 'no-cache, no-store, must-revalidate';
             params.Expires = 0;
+        } else if (config.cacheControl) {
+            params.CacheControl = config.cacheControl;
+        } else {
+            const sec = 1;
+            const min = 60 * sec;
+            const hour = 60 * min;
+            const day = 24 * hour;
+            let localMaxAge = 2 * min;
+            let serverMaxAge = day;
+            if (contentType.startsWith('font/')) {
+                // Rarely changes.
+                localMaxAge = 7 * day;
+                serverMaxAge = 365 * day;
+            } else if (contentType.startsWith('audio/') || contentType.startsWith('video/')) {
+                // media assets are usually stable.
+                localMaxAge = 7 * day;
+                serverMaxAge = 120 * day;
+            }
+            params.CacheControl = `max-age=${localMaxAge} s-maxage=${serverMaxAge} stale-while-revalidate=${5 * min}`;
         }
 
         return util.promisify(s3Client.putObject.bind(s3Client))(params)

--- a/src/deploy/upload-dist.js
+++ b/src/deploy/upload-dist.js
@@ -5,7 +5,7 @@ const path = require("path");
 
 const s3 = require("./s3-upload");
 const accumulateFiles = require("./accumulate-files");
-const getContentType = require("./content-type");
+const { getContentType } = require("./content-type");
 
 // helper function to flatten array
 const flattenDeep = (arr) => {


### PR DESCRIPTION
### JIRA
* [PI-2316](https://infillion.atlassian.net/browse/PI-2316): set cache-control header on all uploaded files

### Description
* We need to set the cache control headers explicitly now.
* We put in defaults appropriate to the file types we upload.
* TODO: fix all client repos to use the updated uploadDist() function

### Testing
* upload-tests unit test exercises things pretty well.

### Commit Message Subject(s)
n/a

### Additional Context
n/a

### Related PRs
n/a

# Checks
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
- [x] Includes unit test coverage _(if applicable)_
- [ ] Updated [README.md](../README.md) _(if applicable)_



[PI-2316]: https://infillion.atlassian.net/browse/PI-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ