### PR TITLE
Fix/pi 2316/upload files only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.7.18
+## v1.7.19
 * [PI-2316](https://infillion.atlassian.net/browse/PI-2316): set cache-control header on all uploaded files
 
 ## v1.7.17

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/deploy/__tests__/subfolder/subfile_stub.txt
+++ b/src/deploy/__tests__/subfolder/subfile_stub.txt
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/__tests__/subfolder2/subfile_stub2.txt
+++ b/src/deploy/__tests__/subfolder2/subfile_stub2.txt
@@ -1,0 +1,1 @@
+test stub

--- a/src/deploy/__tests__/upload-tests.js
+++ b/src/deploy/__tests__/upload-tests.js
@@ -8,15 +8,20 @@ require('whatwg-fetch');
 describe("s3 upload tests", () => {
     function expectedCacheControl(filePath) {
         switch (path.extname(filePath).toLowerCase()) {
-            case '.html': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-            case '.js': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-            case '.json': return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
-            case '.ttf': return 'max-age=604800 s-maxage=31536000 stale-while-revalidate=300';
+            case '.ttf':
+                return 'max-age=604800 s-maxage=31536000 stale-while-revalidate=300';
+
             case '.jpg':
-            case '.png': return 'max-age=86400 s-maxage=2592000 stale-while-revalidate=300';
-            case '.mp4': return 'max-age=604800 s-maxage=10368000 stale-while-revalidate=300';
-            case '.mp3': return 'max-age=604800 s-maxage=10368000 stale-while-revalidate=300';
-            default: throw new Error('unknown extension: ' + filePath);
+            case '.png':
+                return 'max-age=86400 s-maxage=2592000 stale-while-revalidate=300';
+
+            case '.mp4':
+            case '.mp3':
+                return 'max-age=604800 s-maxage=10368000 stale-while-revalidate=300';
+
+            // Default for .html, .js, .txt
+            default:
+                return 'max-age=120 s-maxage=86400 stale-while-revalidate=300';
         }
     }
 
@@ -44,11 +49,18 @@ describe("s3 upload tests", () => {
             return;
         }
 
+        jest.setTimeout(10 * 1000);
+
         const bucket = "qa-media.truex.com";
         const bucketPath = "truex-shared/__tests__";
 
+        const duplicates = {};
+
         return s3.cleanFolder(bucket, bucketPath + '/').then(() => {
             return uploadDist(bucket, bucketPath, './src/deploy/__tests__/', {}, (filePath, fileUrl) => {
+                if (duplicates[fileUrl]) throw new Error('file uploaded multiple times: ' + fileUrl);
+                duplicates[fileUrl] = true;
+
                 return purgeFastlyUrl(fileUrl, process.env.FASTLY_API_TOKEN).then(() => {
                     console.log('testing cache controls for ' + fileUrl);
                     return fetch('https://' + fileUrl).then(resp => {

--- a/src/deploy/accumulate-files.js
+++ b/src/deploy/accumulate-files.js
@@ -21,7 +21,6 @@ function accumulateFiles(dir) {
             allFiles.push(filePath);
         }
     });
-    allFiles.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
     return allFiles;
 };
 

--- a/src/deploy/accumulate-files.js
+++ b/src/deploy/accumulate-files.js
@@ -3,43 +3,26 @@ const path = require('path');
 const util = require('util');
 
 /**
- *
- *
+ * Returns a list of all the files in the directory, along with their contents.
  * @param {string} dir
  * @param {array} [list=[]]
  * @returns {array}
  */
-const accumulateFiles = (dir, list = []) => {
+function accumulateFiles(dir) {
     // helper to find all files to upload
-    return util
-        .promisify(fs.readdir)(dir)
-        .then((result) => {
-            // separate files from directories
-            const dirs = [];
-            result.forEach((f) => {
-                const fPath = path.join(dir, f);
-                const stat = fs.statSync(fPath);
-                if (stat.isDirectory()) {
-                    dirs.push(fPath);
-                } else {
-                    list.push(fPath);
-                }
-            });
-
-            // recursively search directories for files to accumulate
-            if (dirs.length) {
-                return Promise.all(
-                    dirs.map((d) => {
-                        return accumulateFiles(d, list);
-                    }),
-                );
-            }
-
-            return list;
-        })
-        .then((list) => {
-            return list;
-        });
+    let allFiles = [];
+    const entries = fs.readdirSync(dir);
+    entries.forEach(f => {
+        const filePath = path.join(dir, f);
+        const stat = fs.statSync(filePath);
+        if (stat.isDirectory()) {
+            allFiles = allFiles.concat(accumulateFiles(filePath));
+        } else {
+            allFiles.push(filePath);
+        }
+    });
+    allFiles.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+    return allFiles;
 };
 
 module.exports = accumulateFiles;

--- a/src/deploy/accumulate-files.js
+++ b/src/deploy/accumulate-files.js
@@ -5,7 +5,6 @@ const util = require('util');
 /**
  * Returns a list of all the files in the directory, along with their contents.
  * @param {string} dir
- * @param {array} [list=[]]
  * @returns {array}
  */
 function accumulateFiles(dir) {


### PR DESCRIPTION
### JIRA
* [PI-2316](https://infillion.atlassian.net/browse/PI-2316): set cache-control header on all uploaded files

### Description
* Fix uploadDist to ensure files are only uploaded once.

### Testing
* Added subfolders that exercise duplicate upload bug.
* Unit test now verifies avoidance of duplicates.

### Commit Message Subject(s)
n/a

### Additional Context
n/a

### Related PRs
n/a

# Checks
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
- [x] Includes unit test coverage _(if applicable)_
- [ ] Updated [README.md](../README.md) _(if applicable)_



[PI-2316]: https://infillion.atlassian.net/browse/PI-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ