### PR TITLE
Make the URL param function recursive to support encoding of deep objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.9.1
+* [ADX-237](https://infillion.atlassian.net/browse/ADX-237): make encodeUrlParams() recursive
+
 ## v1.9.0
 * [PI-2416](https://infillion.atlassian.net/browse/PI-2416): support POPUP_WEBSITE ad event on all platforms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -12,7 +12,7 @@ describe('encodeUrlParams', () => {
     });
 
     it('should encode objects recursively', () => {
-        const params = { a: 1, b: 2, c: [1], d: {e: 0} };
+        const params = { a: 1, b: 2, c: [1], d: {e: 0}, f: [], g: {} };
         expect(encodeUrlParams(params)).toBe('a=1&b=2&c%5B0%5D=1&d%5Be%5D=0');
     });
 });

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -10,6 +10,11 @@ describe('encodeUrlParams', () => {
         const params = { a: 'foo&', 'b@': 'bar' };
         expect(encodeUrlParams(params)).toBe('a=foo%26&b%40=bar');
     });
+
+    it('should encode objects recursively', () => {
+        const params = { a: 1, b: 2, c: [1], d: {e: 0} };
+        expect(encodeUrlParams(params)).toBe('a=1&b=2&c%5B0%5D=1&d%5Be%5D=0');
+    });
 });
 
 describe('parseQueryArgs', () => {

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -65,16 +65,20 @@ export function encodeUrlParams(obj, keyPrefix) {
       currentKey = encodeURIComponent(key);
     }
 
-    if (value !== null && typeof value === 'object' && Object.keys(value).length > 0) {
-      // Recurse into non-scaler objects.
-      pairs.push(encodeUrlParams(value, currentKey));
-    }
-    else if (value !== null) {
-      // Encode scaler objects (e.g. Date) and everything else (e.g. boolean).
+    if (typeof value === 'object') {
+        const isArray = value.constructor == Array;
+        const isHash = value.constructor == Object;
+
+        if (!isArray && !isHash) {
+            // Encode scaler objects (e.g. Date)
+            pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);
+        } else if (Object.keys(value).length > 0) {
+            // Recurse into non-empty, non-scaler objects
+            pairs.push(encodeUrlParams(value, currentKey));
+        }
+    } else if (value != null) {
+      // Encode everything else (e.g. string, number, boolean).
       pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);
-    }
-    else {
-      pairs.push(`${currentKey}=`);
     }
   }
 

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -45,15 +45,38 @@ export function parseArgs(queryArgs, splitString) {
  * @param {object} - object of key and its corresponding values
  * @returns {string} - urlencoded query string
  */
-export function encodeUrlParams (params, prefix) {
-    const encodedParams = Object.keys(params).map(name => {
-        const value = params[name];
-        if (value === undefined) {
-            return undefined; // no value
-        }
-        const encodedName =  encodeURIComponent(prefix ? prefix + '[' + name + ']' : name);
-        const encodedValue = encodeURIComponent(value);
-        return encodedName + '=' + encodedValue;
-    }).filter(field => field != undefined).join('&');
-    return encodedParams;
-};
+export function encodeUrlParams(obj, keyPrefix) {
+  const pairs = [];
+
+  for (const key in obj) {
+    if (!obj.hasOwnProperty(key)) {
+      continue;
+    }
+
+    const value = obj[key];
+    let currentKey;
+
+    // If we have a keyPrefix, it means we're within a nested object.
+    // So we need to include it in our encoded key, in the form "keyPrefix[key]".
+    if (keyPrefix) {
+      currentKey = `${keyPrefix}${encodeURIComponent('['+key+']')}`;
+    }
+    else {
+      currentKey = encodeURIComponent(key);
+    }
+
+    if (value !== null && typeof value === 'object' && Object.keys(value).length > 0) {
+      // Recurse into non-scaler objects.
+      pairs.push(encodeUrlParams(value, currentKey));
+    }
+    else if (value !== null) {
+      // Encode scaler objects (e.g. Date) and everything else (e.g. boolean).
+      pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);
+    }
+    else {
+      pairs.push(`${currentKey}=`);
+    }
+  }
+
+  return pairs.join('&');
+}


### PR DESCRIPTION
### JIRA
https://infillion.atlassian.net/browse/ADX-237

### Description
Currently the URL param encoder can only handle flat objects. We need to support deeper structures.

### Testing
run `npm test`

### Commit Message Subject(s)
Make the URL param encoder function recursive to allow encoding of deep objects

### Related PRs
https://github.com/socialvibe/container_core/pull/678

### Checks
- [x ] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [ ] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

