### PR TITLE
add engageSeverUrl field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.9.1
+* [PI-2407](https://infillion.atlassian.net/browse/PI-2407): Bug - C3 Container does not work with Hulu Desktop, specifically hulu.js
+  * add TruexServers.engageServerUrl 
+
 ## v1.9.0
 * [PI-2416](https://infillion.atlassian.net/browse/PI-2416): support POPUP_WEBSITE ad event on all platforms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -13,8 +13,12 @@ describe("truex_servers testing", () => {
         expect(isTruexProductionUrl("https://qa-media.truex.com")).toBe(false);
         expect(isTruexProductionUrl("https://qa-server.truex.com")).toBe(false);
         expect(isTruexProductionUrl("https://media.somewhere.else.com")).toBe(false);
+
         expect(isTruexProductionUrl("qa-media.truex.com")).toBe(false);
         expect(isTruexProductionUrl("media.truex.com")).toBe(true);
+
+        expect(isTruexProductionUrl("http://engage.truex.com")).toBe(true);
+        expect(isTruexProductionUrl("http://qa-engage.truex.com")).toBe(false);
     });
 
     test("truex servers", () => {
@@ -59,11 +63,13 @@ describe("truex_servers testing", () => {
                 expect(servers.truexServerUrl).toBe("https://serve.truex.com");
                 expect(servers.mediaServerUrl).toBe("https://media.truex.com");
                 expect(servers.measureServerUrl).toBe("https://measure.truex.com");
+                expect(servers.engageServerUrl).toBe("https://engage.truex.com");
                 expect(servers.serverUrlOf("something.truex.com")).toBe("https://something.truex.com");
             } else {
                 expect(servers.truexServerUrl).toBe("https://qa-serve.truex.com");
                 expect(servers.mediaServerUrl).toBe("https://qa-media.truex.com");
                 expect(servers.measureServerUrl).toBe("https://qa-measure.truex.com");
+                expect(servers.engageServerUrl).toBe("https://qa-engage.truex.com");
                 expect(servers.serverUrlOf("something.truex.com")).toBe("https://qa-something.truex.com");
             }
         }

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -31,9 +31,14 @@ export class TruexServers {
 
         this.isProduction = isProd;
 
-        this.truexServerUrl = serverUrlOf('serve.truex.com');
+        this.engageServerUrl = serverUrlOf('engage.truex.com');
         this.mediaServerUrl = serverUrlOf('media.truex.com');
         this.measureServerUrl = serverUrlOf('measure.truex.com');
+
+        /**
+         * @deprecated use engage.truex.com instead. serve.truex.com is now just a redirect to it.
+         */
+        this.truexServerUrl = serverUrlOf('serve.truex.com');
 
         this.serverUrlOf = serverUrlOf;
 


### PR DESCRIPTION
add new field for engage.truex.com in preparation to migrate to that throughout in later PRs, away from serve.truex.com, which is now deprecated.