### PR TITLE
Fix/pi 2519/encode url parms fix for user opt capping fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.10.0
+## v1.10.1
 * [PI-2519](https://infillion.atlassian.net/browse/PI-2519): User Opt-Out Capping (Nephew Rule) is not actually stopping Choicecard from loading in
   * fix encodeUrlParams to not crash with null
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.10.0
 * [PI-2519](https://infillion.atlassian.net/browse/PI-2519): User Opt-Out Capping (Nephew Rule) is not actually stopping Choicecard from loading in
-* fix encodeUrlParams to not crash with null
+  * fix encodeUrlParams to not crash with null
 
 ## v1.9.2
 * [PI-2407](https://infillion.atlassian.net/browse/PI-2407): Bug - C3 Container does not work with Hulu Desktop, specifically hulu.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.10.0
+* [PI-2519](https://infillion.atlassian.net/browse/PI-2519): User Opt-Out Capping (Nephew Rule) is not actually stopping Choicecard from loading in
+* fix encodeUrlParams to not crash with null
+
 ## v1.9.2
 * [PI-2407](https://infillion.atlassian.net/browse/PI-2407): Bug - C3 Container does not work with Hulu Desktop, specifically hulu.js
   * add TruexServers.engageServerUrl 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.9.2",
+  "version": "1.10.0",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -20,6 +20,36 @@ describe('encodeUrlParams', () => {
         const params = { zero: 0, "false": false, empty: "", "null": null, "undefined": undefined, something: "else" };
         expect(encodeUrlParams(params)).toBe('zero=0&false=false&empty=&something=else');
     });
+
+    it('should tolerate functions, class instances', () => {
+        const f = function() {return 1};
+        f.a = 1;
+        expect(encodeUrlParams(f)).toBe('a=1');
+
+        class Foo {
+            constructor(value) {
+                this.value = value;
+            }
+
+            method() {
+                // should be ignored
+            }
+        }
+        const foo = new Foo(123);
+        expect(encodeUrlParams(foo)).toBe('value=123');
+    });
+
+    it('should ignore function fields, handle dates', () => {
+        const now = new Date();
+        const params = {
+            field: 123,
+            date: now,
+            method: function() {
+                return 1
+            }
+        }
+        expect(encodeUrlParams(params)).toBe('field=123&date=' + encodeURIComponent(now.toString()));
+    });
 });
 
 describe('parseQueryArgs', () => {

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -15,6 +15,11 @@ describe('encodeUrlParams', () => {
         const params = { a: 1, b: 2, c: [1], d: {e: 0}, f: [], g: {} };
         expect(encodeUrlParams(params)).toBe('a=1&b=2&c%5B0%5D=1&d%5Be%5D=0');
     });
+
+    it('should skip empty values', () => {
+        const params = { zero: 0, "false": false, empty: "", "null": null, "undefined": undefined };
+        expect(encodeUrlParams(params)).toBe('zero=0&false=false');
+    });
 });
 
 describe('parseQueryArgs', () => {

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -17,14 +17,14 @@ describe('encodeUrlParams', () => {
     });
 
     it('should skip empty values', () => {
-        const params = { zero: 0, "false": false, empty: "", "null": null, "undefined": undefined };
-        expect(encodeUrlParams(params)).toBe('zero=0&false=false');
+        const params = { zero: 0, "false": false, empty: "", "null": null, "undefined": undefined, something: "else" };
+        expect(encodeUrlParams(params)).toBe('zero=0&false=false&empty=&something=else');
     });
 });
 
 describe('parseQueryArgs', () => {
     it('should return the params of the url', () => {
-        const url = "www.test.com?a=1&b=2";
-        expect(parseQueryArgs(url, '&', '?')).toEqual({ a: '1', b: '2' });
+        const url = "www.test.com?a=1&b=2&empty=";
+        expect(parseQueryArgs(url, '&', '?')).toEqual({ a: '1', b: '2', empty: "" });
     });
 });

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -41,9 +41,19 @@ describe('encodeUrlParams', () => {
 
     it('should ignore function fields, handle dates', () => {
         const now = new Date();
+        class Foo {
+            constructor(value) {
+                this.value = value;
+            }
+
+            method() {
+                // should be ignored
+            }
+        }
         const params = {
             field: 123,
             date: now,
+            foo: new Foo('foo'),
             method: function() {
                 return 1
             }

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -16,7 +16,7 @@ describe('encodeUrlParams', () => {
         expect(encodeUrlParams(params)).toBe('a=1&b=2&c%5B0%5D=1&d%5Be%5D=0');
     });
 
-    it('should skip empty values', () => {
+    it('should skip missing values', () => {
         const params = { zero: 0, "false": false, empty: "", "null": null, "undefined": undefined, something: "else" };
         expect(encodeUrlParams(params)).toBe('zero=0&false=false&empty=&something=else');
     });

--- a/src/utils/__tests__/url_params-test.js
+++ b/src/utils/__tests__/url_params-test.js
@@ -52,13 +52,13 @@ describe('encodeUrlParams', () => {
         }
         const params = {
             field: 123,
-            date: now,
             foo: new Foo('foo'),
+            date: now,
             method: function() {
                 return 1
             }
         }
-        expect(encodeUrlParams(params)).toBe('field=123&date=' + encodeURIComponent(now.toString()));
+        expect(encodeUrlParams(params)).toBe('field=123&foo%5Bvalue%5D=foo&date=' + encodeURIComponent(now.toString()));
     });
 });
 

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -73,11 +73,8 @@ export function encodeUrlParams(obj, keyPrefix) {
         // Skip missing values.
 
     } else if (value instanceof Object) {
-        const isArray = Array.isArray(value);
-        const isPlainObject = value.constructor == Object;
-
-        if (!isArray && !isPlainObject) {
-            // Encode scalar objects (e.g. Date)
+        if (value instanceof Date) {
+            // Encode dates as scalar values.
             pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);
         } else if (Object.keys(value).length > 0) {
             // Recurse into non-empty, non-scaler objects

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -79,6 +79,7 @@ export function encodeUrlParams(obj, keyPrefix) {
             // Recurse into non-empty, non-scaler objects
             pairs.push(encodeUrlParams(value, currentKey));
         }
+
     } else {
       // Encode everything else (e.g. string, number, boolean).
       pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -55,7 +55,7 @@ export function encodeUrlParams(obj, keyPrefix) {
 
     const value = obj[key];
 
-    // Don't try to serialize actual functions members
+    // Don't try to serialize actual function members
     if (value instanceof Function) continue;
 
     let currentKey;

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -65,7 +65,10 @@ export function encodeUrlParams(obj, keyPrefix) {
       currentKey = encodeURIComponent(key);
     }
 
-    if (typeof value === 'object') {
+    if (value === undefined || value === null || value === "") {
+        // Skip missing values.
+
+    } else if (typeof value === 'object') {
         const isArray = value.constructor == Array;
         const isHash = value.constructor == Object;
 
@@ -76,7 +79,7 @@ export function encodeUrlParams(obj, keyPrefix) {
             // Recurse into non-empty, non-scaler objects
             pairs.push(encodeUrlParams(value, currentKey));
         }
-    } else if (value != null) {
+    } else {
       // Encode everything else (e.g. string, number, boolean).
       pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);
     }

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -54,6 +54,10 @@ export function encodeUrlParams(obj, keyPrefix) {
     }
 
     const value = obj[key];
+
+    // Don't try to serialize actual functions members
+    if (value instanceof Function) continue;
+
     let currentKey;
 
     // If we have a keyPrefix, it means we're within a nested object.
@@ -70,9 +74,9 @@ export function encodeUrlParams(obj, keyPrefix) {
 
     } else if (value instanceof Object) {
         const isArray = Array.isArray(value);
-        const isObject = value.constructor == Object;
+        const isPlainObject = value.constructor == Object;
 
-        if (!isArray && !isObject) {
+        if (!isArray && !isPlainObject) {
             // Encode scalar objects (e.g. Date)
             pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);
         } else if (Object.keys(value).length > 0) {

--- a/src/utils/url_params.js
+++ b/src/utils/url_params.js
@@ -65,15 +65,15 @@ export function encodeUrlParams(obj, keyPrefix) {
       currentKey = encodeURIComponent(key);
     }
 
-    if (value === undefined || value === null || value === "") {
+    if (value === undefined || value === null) {
         // Skip missing values.
 
-    } else if (typeof value === 'object') {
-        const isArray = value.constructor == Array;
-        const isHash = value.constructor == Object;
+    } else if (value instanceof Object) {
+        const isArray = Array.isArray(value);
+        const isObject = value.constructor == Object;
 
-        if (!isArray && !isHash) {
-            // Encode scaler objects (e.g. Date)
+        if (!isArray && !isObject) {
+            // Encode scalar objects (e.g. Date)
             pairs.push(`${currentKey}=${encodeURIComponent(value.toString())}`);
         } else if (Object.keys(value).length > 0) {
             // Recurse into non-empty, non-scaler objects

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,9 +1651,9 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001473"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz"
-  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
+  version "1.0.30001564"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001564.tgz"
+  integrity sha512-DqAOf+rhof+6GVx1y+xzbFPeOumfQnhYzVnZD6LAXijR77yPtm9mfOcqOnT3mpnJiZVT+kwLAFnRlZcIz+c6bg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
in particular, null values were causing crashes because while
```
(null instanceof Object) == false
```
it turns out that
```
typeof null === 'object'
```
which is something people argue about