### PR TITLE
Task/pi 2894/simid client fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v1.11.2
+## v1.11.3
 * [PI-2897](https://infillion.atlassian.net/browse/PI-2897): Create SIMID Core Message component
 
 ## v1.10.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/simid/__tests__/simid-client-tests.js
+++ b/src/simid/__tests__/simid-client-tests.js
@@ -407,7 +407,7 @@ describe('test simid client', () => {
     test('test media events', () => {
         const { player, simidClient, playerWindow } = newStartedTestState();;
 
-        function testEvent(event, args = {}) {
+        function testEvent(event, args) {
             simidClient.onMediaEvent = jest.fn();
 
             const eventListener = jest.fn();
@@ -416,7 +416,8 @@ describe('test simid client', () => {
             player.sendPlayerMessage('SIMID:Media:' + event, args);
             expect(simidClient.onMediaEvent).toHaveBeenCalledWith(event, args);
 
-            const expectedEvent = {...args, type: event};
+            const eventArgs = args || {};
+            const expectedEvent = {...eventArgs, type: event};
             expect(eventListener).toHaveBeenCalledWith(expectedEvent);
 
             // Verify event cleanup

--- a/src/simid/__tests__/simid-client-tests.js
+++ b/src/simid/__tests__/simid-client-tests.js
@@ -407,10 +407,22 @@ describe('test simid client', () => {
     test('test media events', () => {
         const { player, simidClient, playerWindow } = newStartedTestState();;
 
-        function testEvent(event, args) {
+        function testEvent(event, args = {}) {
             simidClient.onMediaEvent = jest.fn();
+
+            const eventListener = jest.fn();
+            simidClient.addEventListener(event, eventListener);
+
             player.sendPlayerMessage('SIMID:Media:' + event, args);
             expect(simidClient.onMediaEvent).toHaveBeenCalledWith(event, args);
+
+            const expectedEvent = {...args, type: event};
+            expect(eventListener).toHaveBeenCalledWith(event, expectedEvent);
+
+            // Verify event cleanup
+            expect(simidClient._eventListeners[event].find(eventListener)).toBeGreaterThanOrEqual(0);
+            simidClient.removeEventListener(event, eventListener);
+            expect(simidClient._eventListeners[event].find(eventListener)).toBe(-1);
         }
 
         testEvent('durationchange', {duration: 123});
@@ -427,10 +439,27 @@ describe('test simid client', () => {
     });
 });
 
-function testPlayerRequest(state, type, args) {
-    const { player, playerWindow } = state;
+function testPlayerRequest(state, type, args, supportsEventListener = true, expectedEventData = {}) {
+    const { player, playerWindow, simidClient } = state;
     const requestMsg = player.sendPlayerMessage(type, args);
+
+    const eventListener = supportsEventListener ? jest.fn() : undefined;
+    const eventType = simidClient._getEventType(type);
+    if (eventListener) {
+        simidClient.addEventListener(eventType, eventListener);
+    }
+
     expect(playerWindow.lastMessage).toEqual(expect.objectContaining({type: 'resolve', args: {messageId: requestMsg.messageId, value: undefined}}));
+
+    if (eventListener) {
+        const expectedEvent = {...expectedEventData, type: eventType};
+        expect(eventListener).toHaveBeenCalledWith(expectedEvent);
+
+        // Verify event cleanup
+        expect(simidClient._eventListeners[eventType].find(eventListener)).toBeGreaterThanOrEqual(0);
+        simidClient.removeEventListener(eventType, eventListener);
+        expect(simidClient._eventListeners[eventType].find(eventListener)).toBe(-1);
+    }
 }
 
 function testPlayerReject(state, type, args, errorCode, errMessage) {

--- a/src/simid/__tests__/simid-client-tests.js
+++ b/src/simid/__tests__/simid-client-tests.js
@@ -1,4 +1,4 @@
-import { SIMIDClient, SIMIDDimensions, SIMIDMessage, SIMIDErrors } from '../simid-client';
+import { SIMIDClient, SIMIDDimensions, SIMIDMessage, SIMIDErrors, SIMIDPlayerConfig } from '../simid-client';
 import { re } from "@babel/core/lib/vendor/import-meta-resolve";
 
 describe('test simid client', () => {
@@ -49,7 +49,7 @@ describe('test simid client', () => {
         expect(playerWindow.lastMessage.type).toBe('createSession');
         player.resolveClientRequest(playerWindow.lastMessage);
 
-        testPlayerRequest(state, 'SIMID:Player:init', { });
+        testPlayerRequest(state, 'SIMID:Player:init', new SIMIDPlayerConfig());
         testPlayerRequest(state, 'SIMID:Player:startCreative', { });
     });
 
@@ -417,12 +417,12 @@ describe('test simid client', () => {
             expect(simidClient.onMediaEvent).toHaveBeenCalledWith(event, args);
 
             const expectedEvent = {...args, type: event};
-            expect(eventListener).toHaveBeenCalledWith(event, expectedEvent);
+            expect(eventListener).toHaveBeenCalledWith(expectedEvent);
 
             // Verify event cleanup
-            expect(simidClient._eventListeners[event].find(eventListener)).toBeGreaterThanOrEqual(0);
+            expect(simidClient._eventListeners[event].indexOf(eventListener)).toBeGreaterThanOrEqual(0);
             simidClient.removeEventListener(event, eventListener);
-            expect(simidClient._eventListeners[event].find(eventListener)).toBe(-1);
+            expect(simidClient._eventListeners[event].indexOf(eventListener)).toBe(-1);
         }
 
         testEvent('durationchange', {duration: 123});
@@ -439,9 +439,8 @@ describe('test simid client', () => {
     });
 });
 
-function testPlayerRequest(state, type, args, supportsEventListener = true, expectedEventData = {}) {
+function testPlayerRequest(state, type, args, supportsEventListener = true) {
     const { player, playerWindow, simidClient } = state;
-    const requestMsg = player.sendPlayerMessage(type, args);
 
     const eventListener = supportsEventListener ? jest.fn() : undefined;
     const eventType = simidClient._getEventType(type);
@@ -449,16 +448,23 @@ function testPlayerRequest(state, type, args, supportsEventListener = true, expe
         simidClient.addEventListener(eventType, eventListener);
     }
 
+    const requestMsg = player.sendPlayerMessage(type, args);
+
     expect(playerWindow.lastMessage).toEqual(expect.objectContaining({type: 'resolve', args: {messageId: requestMsg.messageId, value: undefined}}));
 
     if (eventListener) {
-        const expectedEvent = {...expectedEventData, type: eventType};
+        const eventData = args || {};
+        const expectedEvent = {...eventData, type: eventType};
         expect(eventListener).toHaveBeenCalledWith(expectedEvent);
 
         // Verify event cleanup
-        expect(simidClient._eventListeners[eventType].find(eventListener)).toBeGreaterThanOrEqual(0);
-        simidClient.removeEventListener(eventType, eventListener);
-        expect(simidClient._eventListeners[eventType].find(eventListener)).toBe(-1);
+        if (simidClient.isActive) {
+            expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBeGreaterThanOrEqual(0);
+            simidClient.removeEventListener(eventType, eventListener);
+            expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBe(-1);
+        } else {
+            expect(simidClient._eventListeners).toEqual({});
+        }
     }
 }
 

--- a/src/simid/simid-client.js
+++ b/src/simid/simid-client.js
@@ -590,8 +590,8 @@ export class SIMIDClient {
     }
 
     _getEventType(messageType) {
-        const typeParts = type.split(':');
-        const eventType = typeParts.length == 3 ? typeParts[2] : type;
+        const typeParts = messageType.split(':');
+        const eventType = typeParts.length == 3 ? typeParts[2] : messageType;
         return eventType;
     }
 }

--- a/src/simid/simid-client.js
+++ b/src/simid/simid-client.js
@@ -561,8 +561,9 @@ export class SIMIDClient {
         if (!eventCallbacks) {
             eventCallbacks = [];
             this._eventListeners[type] = eventCallbacks;
-        } else {
-            if (eventCallbacks.find(existingCallback => existingCallback == callback)) return; // already present
+
+        } else if (eventCallbacks.indexOf(callback) >= 0) {
+            return; // already present
         }
         eventCallbacks.push(callback);
     }

--- a/src/simid/simid-client.js
+++ b/src/simid/simid-client.js
@@ -573,7 +573,7 @@ export class SIMIDClient {
         let eventCallbacks = this._eventListeners[type];
         if (!eventCallbacks) return;
 
-        const foundAt = eventCallbacks.find(existingCallback => existingCallback == callback);
+        const foundAt = eventCallbacks.indexOf(callback);
         if (foundAt < 0) return;
 
         eventCallbacks.splice(foundAt, 1);

--- a/src/simid/simid-client.js
+++ b/src/simid/simid-client.js
@@ -494,9 +494,9 @@ export class SIMIDClient {
 
     _mediaEvent(messageId, type, args) {
         try {
-            const event = type.split(':')[2];
-            this.onMediaEvent(event, args);
-            this._invokeEventListeners(type, args);
+            const eventType = this._getEventType(type);
+            this.onMediaEvent(eventType, args);
+            this._invokeEventListeners(eventType, args);
         } catch (error) {
             const message = this.getErrorMessage(args?.message);
             console.error(`SIMID error for media event: ${messageId} - ${type}: ${message}`);

--- a/src/simid/simid-client.js
+++ b/src/simid/simid-client.js
@@ -31,6 +31,8 @@ export class SIMIDClient {
         this.isActive = false;
         this.debug = false;
         this._onPlayerMessage = this._onPlayerMessage.bind(this);
+
+        this._eventListeners = {};
     }
 
     start() {
@@ -49,6 +51,7 @@ export class SIMIDClient {
         this.isActive = false;
         this._contentWindow.removeEventListener('message', this._onPlayerMessage);
         this._pendingClientRequests = {};
+        this._eventListeners = {};
     }
 
     /**
@@ -66,9 +69,11 @@ export class SIMIDClient {
     fatalError(errorCode, errorOrMessage) {
         const message = this.getErrorMessage(errorOrMessage);
         console.error(`SIMID fatal client error: ${errorCode} - ${message}`);
-        this._sendClientMessage('SIMID:Creative:fatalError', {errorCode, message});
+        const errorArgs = {errorCode, message};
+        this._sendClientMessage('SIMID:Creative:fatalError', errorArgs);
         this.stop();
         this.onFatalError(errorCode, message); // in case any completion is needed
+        this._invokeEventListeners('fatalError', errorArgs);
     }
 
     getMediaState() {
@@ -419,17 +424,24 @@ export class SIMIDClient {
 
     _init(requestId, requestType, args) {
         this._playerConfig = new SIMIDPlayerConfig(args);
-        return this._playerResponse(requestId, requestType, () => this.onInit(this._playerConfig));
+        return this._playerResponse(requestId, requestType, () => {
+            this.onInit(this._playerConfig);
+            this._invokeEventListeners(requestType, this._playerConfig);
+        });
     }
 
     _startCreative(requestId, requestType) {
-        return this._playerResponse(requestId, requestType, () => this.onStartCreative());
+        return this._playerResponse(requestId, requestType, () => {
+            this.onStartCreative();
+            this._invokeEventListeners(requestType);
+        });
     }
 
     _playerLog(args) {
         const message = args?.message;
         if (!message) return;
         this.onPlayerLog(message);
+        this._invokeEventListeners('log', { message });
         return message;
     }
 
@@ -437,26 +449,38 @@ export class SIMIDClient {
         const videoDimensions = new SIMIDDimensions(args?.videoDimensions);
         const creativeDimensions = new SIMIDDimensions(args?.creativeDimensions);
         const fullscreen = !!args?.fullscreen;
-        this.onResize({ videoDimensions, creativeDimensions, fullscreen });
+        const resizeArgs = { videoDimensions, creativeDimensions, fullscreen };
+        this.onResize(resizeArgs);
+        this._invokeEventListeners('resize', resizeArgs);
     }
 
     _adSkipped(requestId, requestType) {
         // Stop only after the final message is sent.
-        this._playerResponse(requestId, requestType, () => this.onAdSkipped(), () => this.stop());
+        this._playerResponse(requestId, requestType, () => {
+            this.onAdSkipped();
+            this._invokeEventListeners(requestType);
+        }, () => this.stop());
     }
 
     _adStopped(requestId, requestType) {
         // Stop only after the final message is sent.
-        this._playerResponse(requestId, requestType, () => this.onAdStopped(), () => this.stop());
+        this._playerResponse(requestId, requestType, () => {
+            this.onAdStopped();
+            this._invokeEventListeners(requestType);
+        }, () => this.stop());
     }
 
     _adBackgrounded(requestId, requestType) {
-        return this._playerResponse(requestId, requestType, () => this.onAdBackgrounded());
+        return this._playerResponse(requestId, requestType, () => {
+            this.onAdBackgrounded()
+            this._invokeEventListeners(requestType);
+        });
     }
 
     _adForegrounded(requestId, requestType) {
         // No promise response is sent.
         this.onAdForegrounded();
+        this._invokeEventListeners(requestType);
     }
 
     _playerFatalError(args) {
@@ -465,12 +489,14 @@ export class SIMIDClient {
         console.error(`SIMID fatal player error: ${errorCode} - ${message}`);
         this.stop();
         this.onFatalError(errorCode, message); // in case any completion is needed
+        this._invokeEventListeners('fatalError', { errorCode, message });
     }
 
     _mediaEvent(messageId, type, args) {
         try {
             const event = type.split(':')[2];
             this.onMediaEvent(event, args);
+            this._invokeEventListeners(type, args);
         } catch (error) {
             const message = this.getErrorMessage(args?.message);
             console.error(`SIMID error for media event: ${messageId} - ${type}: ${message}`);
@@ -525,6 +551,48 @@ export class SIMIDClient {
     }
 
     onFatalError(errorCode, message) {
+    }
+
+    // Event listener helpers for convenience.
+
+    addEventListener(type, callback) {
+        if (!callback) return;
+        let eventCallbacks = this._eventListeners[type];
+        if (!eventCallbacks) {
+            eventCallbacks = [];
+            this._eventListeners[type] = eventCallbacks;
+        } else {
+            if (eventCallbacks.find(existingCallback => existingCallback == callback)) return; // already present
+        }
+        eventCallbacks.push(callback);
+    }
+
+    removeEventListener(type, callback) {
+        if (!callback) return;
+        let eventCallbacks = this._eventListeners[type];
+        if (!eventCallbacks) return;
+
+        const foundAt = eventCallbacks.find(existingCallback => existingCallback == callback);
+        if (foundAt < 0) return;
+
+        eventCallbacks.splice(foundAt, 1);
+    }
+
+    _invokeEventListeners(type, data) {
+        const eventType = this._getEventType(type);
+        const eventCallbacks = this._eventListeners[eventType];
+        if (!eventCallbacks || eventCallbacks.length <= 0) return;
+        if (!data) data = {};
+        const event = {...data, type: eventType};
+        eventCallbacks.forEach(callback => {
+            callback(event);
+        });
+    }
+
+    _getEventType(messageType) {
+        const typeParts = type.split(':');
+        const eventType = typeParts.length == 3 ? typeParts[2] : type;
+        return eventType;
     }
 }
 


### PR DESCRIPTION
Jira: [PI-2895](https://infillion.atlassian.net/browse/PI-2895): Create a new end point for SIMID support to be loaded into ad's iframe as creative file

Support addEventListener for any player message types, as a convenience for ad creative developers
i.e. it is easier to migrate media event listening this way.

[PI-2895]: https://infillion.atlassian.net/browse/PI-2895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ