### PR TITLE
player config fixes: use environmentData field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-## v1.11.3
+## v1.11.4
+* [PI-2895](https://infillion.atlassian.net/browse/PI-2895): Create a new end point for SIMID support to be loaded into ad's iframe as creative file
 * [PI-2897](https://infillion.atlassian.net/browse/PI-2897): Create SIMID Core Message component
 
 ## v1.10.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.11.3",
+  "version": "1.11.4",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/simid/__tests__/simid-client-tests.js
+++ b/src/simid/__tests__/simid-client-tests.js
@@ -247,12 +247,12 @@ describe('test simid client', () => {
         const duration = 123;
         const requestArgs = { duration };
 
-        simidClient._playerConfig = { variableDurationAllowed: false };
+        simidClient._playerConfig = { environmentData: {variableDurationAllowed: false} };
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestChangeAdDuration(duration),
             SIMIDErrors.unspecifiedClientError, 'requestChangeAdDuration not allowed when variableDurationAllowed is false');
 
-        simidClient._playerConfig = { variableDurationAllowed: true };
+        simidClient._playerConfig = { environmentData: {variableDurationAllowed: true} };
         await testClientRequest(state, 'SIMID:Creative:requestChangeAdDuration', requestArgs,
             () => simidClient.requestChangeAdDuration(duration), undefined);
         await testClientReject(state, 'SIMID:Creative:requestChangeAdDuration', requestArgs,
@@ -280,11 +280,11 @@ describe('test simid client', () => {
         const state = newStartedTestState();
         const { simidClient } = state;
 
-        simidClient._playerConfig = { fullscreenAllowed: false };
+        simidClient._playerConfig = { environmentData: {fullscreenAllowed: false} };
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestFullscreen(), SIMIDErrors.unspecifiedClientError, 'requestFullscreen not allowed when fullscreenAllowed is false');
 
-        simidClient._playerConfig = { fullscreenAllowed: true };
+        simidClient._playerConfig = { environmentData: {fullscreenAllowed: true} };
         await testClientRequest(state, 'SIMID:Creative:requestFullscreen', undefined,
             () => simidClient.requestFullscreen(), undefined);
 
@@ -296,11 +296,11 @@ describe('test simid client', () => {
         const state = newStartedTestState();
         const { simidClient } = state;
 
-        simidClient._playerConfig = { fullscreenAllowed: false };
+        simidClient._playerConfig = { environmentData: { fullscreenAllowed: false} };
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestExitFullscreen(), SIMIDErrors.unspecifiedClientError, 'requestExitFullscreen not allowed when fullscreenAllowed is false');
 
-        simidClient._playerConfig = { fullscreenAllowed: true };
+        simidClient._playerConfig = { environmentData: {fullscreenAllowed: true} };
         await testClientRequest(state, 'SIMID:Creative:requestExitFullscreen', undefined,
             () => simidClient.requestExitFullscreen(), undefined);
 
@@ -312,7 +312,7 @@ describe('test simid client', () => {
         const state = newStartedTestState();
         const { simidClient } = state;
 
-        simidClient._playerConfig = { navigationSupport: 'adHandles' };
+        simidClient._playerConfig = { environmentData: {navigationSupport: 'adHandles'} };
         const callArgs = {
             x: 1, y: 2, uri: 'some uri'
         }
@@ -323,7 +323,7 @@ describe('test simid client', () => {
         await testClientRequest(state, 'SIMID:Creative:clickThru', requestArgs,
             () => simidClient.clickThru(callArgs), undefined);
 
-        simidClient._playerConfig = { navigationSupport: 'playerHandles' };
+        simidClient._playerConfig = { environmentData: {navigationSupport: 'playerHandles'} };
         requestArgs.playerHandles = true;
         await testClientRequest(state, 'SIMID:Creative:clickThru', requestArgs,
             () => simidClient.clickThru(callArgs), undefined);
@@ -350,12 +350,12 @@ describe('test simid client', () => {
         const state = newStartedTestState();
         const { simidClient } = state;
 
-        simidClient._playerConfig = { variableDurationAllowed: false };
+        simidClient._playerConfig = { environmentData: {variableDurationAllowed: false} };
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestPause(),
             SIMIDErrors.unspecifiedClientError, 'requestPause not allowed when variableDurationAllowed is false');
 
-        simidClient._playerConfig = { variableDurationAllowed: true };
+        simidClient._playerConfig = { environmentData: {variableDurationAllowed: true} };
         await testClientRequest(state, 'SIMID:Creative:requestPause', undefined,
             () => simidClient.requestPause(), undefined);
         await testClientReject(state, 'SIMID:Creative:requestPause', undefined,
@@ -367,12 +367,12 @@ describe('test simid client', () => {
         const state = newStartedTestState();
         const { simidClient } = state;
 
-        simidClient._playerConfig = { variableDurationAllowed: false };
+        simidClient._playerConfig = { environmentData: {variableDurationAllowed: false} };
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestPlay(),
             SIMIDErrors.unspecifiedClientError, 'requestPlay not allowed when variableDurationAllowed is false');
 
-        simidClient._playerConfig = { variableDurationAllowed: true };
+        simidClient._playerConfig = { environmentData: {variableDurationAllowed: true} };
         await testClientRequest(state, 'SIMID:Creative:requestPlay', undefined,
             () => simidClient.requestPlay(), undefined);
         await testClientReject(state, 'SIMID:Creative:requestPlay', undefined,

--- a/src/simid/simid-client.js
+++ b/src/simid/simid-client.js
@@ -84,7 +84,7 @@ export class SIMIDClient {
     }
 
     clickThru({ x, y, uri }) {
-        const playerHandles = this._playerConfig?.navigationSupport == 'playerHandles';
+        const playerHandles = this._playerConfig?.environmentData.navigationSupport == 'playerHandles';
         return this._sendClientRequest('SIMID:Creative:clickThru', {x, y, playerHandles, uri });
     }
 
@@ -105,7 +105,7 @@ export class SIMIDClient {
      * @return {Promise<unknown>}
      */
     requestChangeAdDuration(duration) {
-        const variableDurationAllowed = this._playerConfig?.variableDurationAllowed;
+        const variableDurationAllowed = this._playerConfig?.environmentData.variableDurationAllowed;
         if (!variableDurationAllowed) {
             return Promise.reject(this._newClientError(SIMIDErrors.unspecifiedClientError,
                 'requestChangeAdDuration not allowed when variableDurationAllowed is false'));
@@ -126,7 +126,7 @@ export class SIMIDClient {
      * @return {Promise<unknown>}
      */
     requestFullscreen() {
-        const fullscreenAllowed = this._playerConfig?.fullscreenAllowed;
+        const fullscreenAllowed = this._playerConfig?.environmentData.fullscreenAllowed;
         if (!fullscreenAllowed) {
             return Promise.reject(this._newClientError(SIMIDErrors.unspecifiedClientError,
                 'requestFullscreen not allowed when fullscreenAllowed is false'));
@@ -138,7 +138,7 @@ export class SIMIDClient {
      * @return {Promise<unknown>}
      */
     requestExitFullscreen() {
-        const fullscreenAllowed = this._playerConfig?.fullscreenAllowed;
+        const fullscreenAllowed = this._playerConfig?.environmentData.fullscreenAllowed;
         if (!fullscreenAllowed) {
             return Promise.reject(this._newClientError(SIMIDErrors.unspecifiedClientError,
                 'requestExitFullscreen not allowed when fullscreenAllowed is false'));
@@ -158,7 +158,7 @@ export class SIMIDClient {
      * @return {Promise<unknown>}
      */
     requestPause() {
-        const canPause = this._playerConfig?.variableDurationAllowed;
+        const canPause = this._playerConfig?.environmentData.variableDurationAllowed;
         if (!canPause) {
             return Promise.reject(this._newClientError(SIMIDErrors.unspecifiedClientError,
                 'requestPause not allowed when variableDurationAllowed is false'));
@@ -170,7 +170,7 @@ export class SIMIDClient {
      * @return {Promise<unknown>}
      */
     requestPlay() {
-        const canPlay = this._playerConfig?.variableDurationAllowed;
+        const canPlay = this._playerConfig?.environmentData.variableDurationAllowed;
         if (!canPlay) {
             return Promise.reject(this._newClientError(SIMIDErrors.unspecifiedClientError,
                 'requestPlay not allowed when variableDurationAllowed is false'));


### PR DESCRIPTION
jira: [PI-2895](https://infillion.atlassian.net/browse/PI-2895): Create a new end point for SIMID support to be loaded into ad's iframe as creative file

quick PR to correct player config usage

[PI-2895]: https://infillion.atlassian.net/browse/PI-2895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ