### PR TITLE
support async ad stopped and ad skipped responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [

--- a/src/simid/__tests__/simid-client-tests.js
+++ b/src/simid/__tests__/simid-client-tests.js
@@ -79,9 +79,10 @@ describe('test simid client', () => {
 
         simidClient.onAdSkipped = jest.fn();
         testPlayerRequest(state, 'SIMID:Player:adSkipped');
-        expect(simidClient.isActive).toBe(false);
-        expect(adWindow.onPostMessage).toBeUndefined(); // i.e. removeEventListener was called
+        expect(simidClient.isActive).toBe(true);
+        expect(simidClient.isStopped).toBe(true);
         expect(simidClient.onAdSkipped).toHaveBeenCalled();
+        expect(adWindow.onPostMessage).toBeUndefined(); // i.e. removeEventListener was called
     });
 
     test('test adSkipped reject', async () => {
@@ -93,6 +94,29 @@ describe('test simid client', () => {
         testPlayerReject(state, 'SIMID:Player:adSkipped', { }, SIMIDErrors.adInternalError, errMessage);
     });
 
+    test('test async ad skipped', async () => {
+        const state = newStartedTestState();
+        const { simidClient } = state;
+        expect(simidClient.isActive).toBe(true);
+
+        let responsePromise;
+        let resolved = false;
+        simidClient.onAdSkipped = () => {
+            responsePromise = new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    resolved = true;
+                    resolve();
+                }, 50);
+            });
+            return responsePromise;
+        };
+        await testPlayerRequest(state, 'SIMID:Player:adSkipped', undefined, () => {
+            return responsePromise;
+        });
+        expect(simidClient.isStopped).toBe(true);
+        expect(resolved).toBe(true);
+    });
+
     test('test ad stopped', () => {
         const state = newStartedTestState();
         const { simidClient } = state;
@@ -100,8 +124,32 @@ describe('test simid client', () => {
 
         simidClient.onAdStopped = jest.fn();
         testPlayerRequest(state, 'SIMID:Player:adStopped');
-        expect(simidClient.isActive).toBe(false);
+        expect(simidClient.isActive).toBe(true);
+        expect(simidClient.isStopped).toBe(true);
         expect(simidClient.onAdStopped).toHaveBeenCalled();
+    });
+
+    test('test async ad stopped', async () => {
+        const state = newStartedTestState();
+        const { simidClient } = state;
+        expect(simidClient.isActive).toBe(true);
+
+        let responsePromise;
+        let resolved = false;
+        simidClient.onAdStopped = () => {
+            responsePromise = new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    resolved = true;
+                    resolve();
+                }, 50);
+            });
+            return responsePromise;
+        };
+        await testPlayerRequest(state, 'SIMID:Player:adStopped', undefined, () => {
+            return responsePromise;
+        });
+        expect(simidClient.isStopped).toBe(true);
+        expect(resolved).toBe(true);
     });
 
     test('test adStopped reject', async () => {
@@ -192,7 +240,8 @@ describe('test simid client', () => {
         player.sendPlayerMessage('SIMID:Player:fatalError', fatalError);
 
         expect(simidClient.onFatalError).toHaveBeenCalledWith(fatalError.errorCode, fatalError.message);
-        expect(simidClient.isActive).toBe(false);
+        expect(simidClient.isActive).toBe(true);
+        expect(simidClient.isStopped).toBe(true);
     });
 
     test('test client fatalError', () => {
@@ -201,7 +250,8 @@ describe('test simid client', () => {
         const fatalError = { errorCode: 999, message: 'test client error' };
         simidClient.fatalError(fatalError.errorCode, fatalError.message);
         expect(playerWindow.lastMessage.args).toEqual(fatalError);
-        expect(simidClient.isActive).toBe(false);
+        expect(simidClient.isActive).toBe(true);
+        expect(simidClient.isStopped).toBe(true);
     });
 
     test('test getMediaState', async () => {
@@ -440,16 +490,18 @@ describe('test simid client', () => {
     });
 });
 
-function testPlayerRequest(state, type, args, supportsEventListener = true) {
+async function testPlayerRequest(state, type, args, waitForResponse) {
     const { player, playerWindow, simidClient } = state;
 
-    const eventListener = supportsEventListener ? jest.fn() : undefined;
+    const eventListener = jest.fn();
     const eventType = simidClient._getEventType(type);
     if (eventListener) {
         simidClient.addEventListener(eventType, eventListener);
     }
 
     const requestMsg = player.sendPlayerMessage(type, args);
+
+    if (waitForResponse) await waitForResponse();
 
     expect(playerWindow.lastMessage).toEqual(expect.objectContaining({type: 'resolve', args: {messageId: requestMsg.messageId, value: undefined}}));
 
@@ -459,12 +511,12 @@ function testPlayerRequest(state, type, args, supportsEventListener = true) {
         expect(eventListener).toHaveBeenCalledWith(expectedEvent);
 
         // Verify event cleanup
-        if (simidClient.isActive) {
+        if (simidClient.isStopped) {
+            expect(simidClient._eventListeners).toEqual({});
+        } else {
             expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBeGreaterThanOrEqual(0);
             simidClient.removeEventListener(eventType, eventListener);
             expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBe(-1);
-        } else {
-            expect(simidClient._eventListeners).toEqual({});
         }
     }
 }

--- a/src/simid/__tests__/simid-client-tests.js
+++ b/src/simid/__tests__/simid-client-tests.js
@@ -1,10 +1,9 @@
 import { SIMIDClient, SIMIDDimensions, SIMIDMessage, SIMIDErrors, SIMIDPlayerConfig } from '../simid-client';
-import { re } from "@babel/core/lib/vendor/import-meta-resolve";
 
 describe('test simid client', () => {
 
     test('start/stop simid client', async () => {
-        const { player, simidClient, playerWindow, adWindow } = newTestState();
+        const {player, simidClient, playerWindow, adWindow} = newTestState();
         expect(simidClient._sessionId).toBeUndefined()
 
         player.sendPlayerMessage('test', {});
@@ -20,7 +19,7 @@ describe('test simid client', () => {
         expect(simidClient._sessionId).toBeDefined();
         let clientMsg = playerWindow.lastMessage;
         expect(clientMsg).toEqual(expect.objectContaining(
-            { sessionId: simidClient._sessionId, messageId: 0, type: 'createSession', args: {} }));
+            {sessionId: simidClient._sessionId, messageId: 0, type: 'createSession', args: {}}));
         expect(clientMsg?.timestamp).toBeLessThanOrEqual(Date.now());
         expect(player.sessionId).toEqual(simidClient._sessionId);
 
@@ -35,13 +34,13 @@ describe('test simid client', () => {
         playerWindow.lastMessage = undefined;
         simidClient.stop();
 
-        player.sendPlayerMessage('SIMID:Player:init', { });
+        player.sendPlayerMessage('SIMID:Player:init', {});
         expect(playerWindow.lastMessage).toBeUndefined();
     });
 
-    test('test initial ad flow', async () => {
+    test('test initial ad flow', () => {
         const state = newTestState();
-        const { player, simidClient, playerWindow, adWindow } = state;
+        const {player, simidClient, playerWindow, adWindow} = state;
 
         simidClient.start();
 
@@ -50,30 +49,30 @@ describe('test simid client', () => {
         player.resolveClientRequest(playerWindow.lastMessage);
 
         testPlayerRequest(state, 'SIMID:Player:init', new SIMIDPlayerConfig());
-        testPlayerRequest(state, 'SIMID:Player:startCreative', { });
+        testPlayerRequest(state, 'SIMID:Player:startCreative', {});
     });
 
-    test('test init reject', async () => {
+    test('test init reject', () => {
         const state = newStartedTestState();
-        const { player, simidClient, playerWindow, adWindow } = state;
+        const {player, simidClient, playerWindow, adWindow} = state;
 
         const errMessage = 'init test error';
         simidClient.onInit = () => { throw new Error(errMessage) };
-        testPlayerReject(state, 'SIMID:Player:init', { }, SIMIDErrors.adInternalError, errMessage);
+        testPlayerReject(state, 'SIMID:Player:init', {}, SIMIDErrors.adInternalError, errMessage);
     });
 
-    test('test startCreative reject', async () => {
+    test('test startCreative reject', () => {
         const state = newStartedTestState();
-        const { player, simidClient, playerWindow, adWindow } = state;
+        const {player, simidClient, playerWindow, adWindow} = state;
 
         const errMessage = 'startCreative test error';
         simidClient.onStartCreative = () => { throw new Error(errMessage) };
-        testPlayerReject(state, 'SIMID:Player:startCreative', { }, SIMIDErrors.adInternalError, errMessage);
+        testPlayerReject(state, 'SIMID:Player:startCreative', {}, SIMIDErrors.adInternalError, errMessage);
     });
 
-    test('test ad skipped', async () => {
+    test('test adSkipped', () => {
         const state = newStartedTestState();
-        const { simidClient, adWindow } = state;
+        const {simidClient, adWindow} = state;
         expect(simidClient.isActive).toBe(true);
         expect(adWindow.onPostMessage).toBeDefined();
 
@@ -85,18 +84,18 @@ describe('test simid client', () => {
         expect(adWindow.onPostMessage).toBeUndefined(); // i.e. removeEventListener was called
     });
 
-    test('test adSkipped reject', async () => {
+    test('test adSkipped reject', () => {
         const state = newStartedTestState();
-        const { player, simidClient, playerWindow, adWindow } = state;
+        const {player, simidClient, playerWindow, adWindow} = state;
 
         const errMessage = 'adSkipped test error';
         simidClient.onAdSkipped = () => { throw new Error(errMessage) };
         testPlayerReject(state, 'SIMID:Player:adSkipped', { }, SIMIDErrors.adInternalError, errMessage);
     });
 
-    test('test async ad skipped', async () => {
+    test('test async adSkipped', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
         expect(simidClient.isActive).toBe(true);
 
         let responsePromise;
@@ -115,9 +114,9 @@ describe('test simid client', () => {
         expect(resolved).toBe(true);
     });
 
-    test('test ad stopped', () => {
+    test('test adStopped', () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
         expect(simidClient.isActive).toBe(true);
 
         simidClient.onAdStopped = jest.fn();
@@ -127,9 +126,17 @@ describe('test simid client', () => {
         expect(simidClient.onAdStopped).toHaveBeenCalled();
     });
 
-    test('test async ad stopped', async () => {
+    test('test adStopped reject', () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {player, simidClient, playerWindow, adWindow} = state;
+        const errMessage = 'adStopped test error';
+        simidClient.onAdStopped = () => {throw new Error(errMessage)};
+        testPlayerReject(state, 'SIMID:Player:adStopped', {}, SIMIDErrors.adInternalError, errMessage);
+    });
+
+    test('test async adStopped', async () => {
+        const state = newStartedTestState();
+        const {simidClient} = state;
         expect(simidClient.isActive).toBe(true);
 
         let responsePromise;
@@ -139,7 +146,7 @@ describe('test simid client', () => {
                 setTimeout(() => {
                     resolved = true;
                     resolve();
-                }, 50);
+                }, 2000);
             });
             return responsePromise;
         };
@@ -148,17 +155,8 @@ describe('test simid client', () => {
         expect(resolved).toBe(true);
     });
 
-    test('test adStopped reject', async () => {
-        const state = newStartedTestState();
-        const { player, simidClient, playerWindow, adWindow } = state;
-
-        const errMessage = 'adStopped test error';
-        simidClient.onAdStopped = () => { throw new Error(errMessage) };
-        testPlayerReject(state, 'SIMID:Player:adStopped', { }, SIMIDErrors.adInternalError, errMessage);
-    });
-
     test('test logging', () => {
-        const { player, simidClient, playerWindow } = newStartedTestState();
+        const {player, simidClient, playerWindow} = newStartedTestState();
 
         simidClient.debug = true; // also see how things log
 
@@ -173,7 +171,7 @@ describe('test simid client', () => {
     });
 
     test('test resize', () => {
-        const { player, simidClient } = newStartedTestState();
+        const {player, simidClient} = newStartedTestState();
 
         const videoDimensions = {x: 1, y: 2, width: 3, height: 4};
         const creativeDimensions = {x: 5, y: 6, width: 7, height: 8};
@@ -181,21 +179,21 @@ describe('test simid client', () => {
 
         simidClient.onResize = jest.fn();
         player.sendPlayerMessage('SIMID:Player:resize', {videoDimensions, creativeDimensions, fullscreen});
-        expect(simidClient.onResize).toHaveBeenCalledWith({ videoDimensions, creativeDimensions, fullscreen });
+        expect(simidClient.onResize).toHaveBeenCalledWith({videoDimensions, creativeDimensions, fullscreen});
     });
 
-    test('test resize reject', async () => {
+    test('test resize reject', () => {
         const state = newStartedTestState();
-        const { player, simidClient, playerWindow, adWindow } = state;
+        const {player, simidClient, playerWindow, adWindow} = state;
 
         const errMessage = 'resize test error';
         simidClient.onResize = () => { throw new Error(errMessage) };
-        testPlayerReject(state, 'SIMID:Player:resize', { }, SIMIDErrors.adInternalError, errMessage);
+        testPlayerReject(state, 'SIMID:Player:resize', {}, SIMIDErrors.adInternalError, errMessage);
     });
 
     test('test requestResize', () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         const resizeArgs = {
             mediaDimensions: {x: 1, y: 2, width: 3, height: 4},
@@ -206,7 +204,7 @@ describe('test simid client', () => {
     });
 
     test('test background/foreground', () => {
-        const { player, simidClient } = newStartedTestState();
+        const {player, simidClient} = newStartedTestState();
 
         simidClient.onAdBackgrounded = jest.fn();
         player.sendPlayerMessage('SIMID:Player:adBackgrounded');
@@ -217,21 +215,21 @@ describe('test simid client', () => {
         expect(simidClient.onAdForegrounded).toHaveBeenCalled();
     });
 
-    test('test backgrounded reject', async () => {
+    test('test backgrounded reject', () => {
         const state = newStartedTestState();
-        const { player, simidClient, playerWindow, adWindow } = state;
+        const {player, simidClient, playerWindow, adWindow} = state;
 
         const errMessage = 'adBackgrounded test error';
         simidClient.onAdBackgrounded = () => { throw new Error(errMessage) };
-        testPlayerReject(state, 'SIMID:Player:adBackgrounded', { }, SIMIDErrors.adInternalError, errMessage);
+        testPlayerReject(state, 'SIMID:Player:adBackgrounded', {}, SIMIDErrors.adInternalError, errMessage);
     });
 
     test('test player fatalError', () => {
-        const { player, simidClient } = newStartedTestState();
+        const {player, simidClient} = newStartedTestState();
 
         simidClient.debug = true; // also see how things log
 
-        const fatalError = { errorCode: 999, message: 'test player error' };
+        const fatalError = {errorCode: 999, message: 'test player error'};
         simidClient.onFatalError = jest.fn();
         player.sendPlayerMessage('SIMID:Player:fatalError', fatalError);
 
@@ -241,9 +239,9 @@ describe('test simid client', () => {
     });
 
     test('test client fatalError', () => {
-        const { simidClient, playerWindow } = newStartedTestState();;
+        const { simidClient, playerWindow } = newStartedTestState();
 
-        const fatalError = { errorCode: 999, message: 'test client error' };
+        const fatalError = {errorCode: 999, message: 'test client error'};
         simidClient.fatalError(fatalError.errorCode, fatalError.message);
         expect(playerWindow.lastMessage.args).toEqual(fatalError);
         expect(simidClient.isActive).toBe(true);
@@ -252,7 +250,7 @@ describe('test simid client', () => {
 
     test('test getMediaState', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         const result = {
             currentSrc: 'https://media.truex.com/some-video.mp4',
@@ -270,7 +268,7 @@ describe('test simid client', () => {
 
     test('test reportTracking', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         const requestArgs = {
             trackingUrls: [
@@ -288,17 +286,17 @@ describe('test simid client', () => {
 
     test('test requestChangeAdDuration', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         const duration = 123;
-        const requestArgs = { duration };
+        const requestArgs = {duration};
 
-        simidClient._playerConfig = { environmentData: {variableDurationAllowed: false} };
+        simidClient._playerConfig = {environmentData: {variableDurationAllowed: false}};
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestChangeAdDuration(duration),
             SIMIDErrors.unspecifiedClientError, 'requestChangeAdDuration not allowed when variableDurationAllowed is false');
 
-        simidClient._playerConfig = { environmentData: {variableDurationAllowed: true} };
+        simidClient._playerConfig = {environmentData: {variableDurationAllowed: true}};
         await testClientRequest(state, 'SIMID:Creative:requestChangeAdDuration', requestArgs,
             () => simidClient.requestChangeAdDuration(duration), undefined);
         await testClientReject(state, 'SIMID:Creative:requestChangeAdDuration', requestArgs,
@@ -308,7 +306,7 @@ describe('test simid client', () => {
 
     test('test requestChangeVolume', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         const requestArgs = {
             volume: 0.8,
@@ -324,13 +322,13 @@ describe('test simid client', () => {
 
     test('test requestFullscreen', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
-        simidClient._playerConfig = { environmentData: {fullscreenAllowed: false} };
+        simidClient._playerConfig = {environmentData: {fullscreenAllowed: false}};
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestFullscreen(), SIMIDErrors.unspecifiedClientError, 'requestFullscreen not allowed when fullscreenAllowed is false');
 
-        simidClient._playerConfig = { environmentData: {fullscreenAllowed: true} };
+        simidClient._playerConfig = {environmentData: {fullscreenAllowed: true}};
         await testClientRequest(state, 'SIMID:Creative:requestFullscreen', undefined,
             () => simidClient.requestFullscreen(), undefined);
 
@@ -340,13 +338,13 @@ describe('test simid client', () => {
 
     test('test requestExitFullscreen', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
-        simidClient._playerConfig = { environmentData: { fullscreenAllowed: false} };
+        simidClient._playerConfig = {environmentData: {fullscreenAllowed: false}};
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestExitFullscreen(), SIMIDErrors.unspecifiedClientError, 'requestExitFullscreen not allowed when fullscreenAllowed is false');
 
-        simidClient._playerConfig = { environmentData: {fullscreenAllowed: true} };
+        simidClient._playerConfig = {environmentData: {fullscreenAllowed: true}};
         await testClientRequest(state, 'SIMID:Creative:requestExitFullscreen', undefined,
             () => simidClient.requestExitFullscreen(), undefined);
 
@@ -356,9 +354,9 @@ describe('test simid client', () => {
 
     test('test clickThru', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
-        simidClient._playerConfig = { environmentData: {navigationSupport: 'adHandles'} };
+        simidClient._playerConfig = {environmentData: {navigationSupport: 'adHandles'}};
         const callArgs = {
             x: 1, y: 2, uri: 'some uri'
         }
@@ -369,7 +367,7 @@ describe('test simid client', () => {
         await testClientRequest(state, 'SIMID:Creative:clickThru', requestArgs,
             () => simidClient.clickThru(callArgs), undefined);
 
-        simidClient._playerConfig = { environmentData: {navigationSupport: 'playerHandles'} };
+        simidClient._playerConfig = {environmentData: {navigationSupport: 'playerHandles'}};
         requestArgs.playerHandles = true;
         await testClientRequest(state, 'SIMID:Creative:clickThru', requestArgs,
             () => simidClient.clickThru(callArgs), undefined);
@@ -380,10 +378,10 @@ describe('test simid client', () => {
 
     test('test requestNavigation', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         const uri = 'some uri';
-        const requestArgs = { uri };
+        const requestArgs = {uri};
 
         await testClientRequest(state, 'SIMID:Creative:requestNavigation', requestArgs,
             () => simidClient.requestNavigation(uri), undefined);
@@ -394,14 +392,14 @@ describe('test simid client', () => {
 
     test('test requestPause', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
-        simidClient._playerConfig = { environmentData: {variableDurationAllowed: false} };
+        simidClient._playerConfig = {environmentData: {variableDurationAllowed: false}};
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestPause(),
             SIMIDErrors.unspecifiedClientError, 'requestPause not allowed when variableDurationAllowed is false');
 
-        simidClient._playerConfig = { environmentData: {variableDurationAllowed: true} };
+        simidClient._playerConfig = {environmentData: {variableDurationAllowed: true}};
         await testClientRequest(state, 'SIMID:Creative:requestPause', undefined,
             () => simidClient.requestPause(), undefined);
         await testClientReject(state, 'SIMID:Creative:requestPause', undefined,
@@ -411,14 +409,14 @@ describe('test simid client', () => {
 
     test('test requestPlay', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
-        simidClient._playerConfig = { environmentData: {variableDurationAllowed: false} };
+        simidClient._playerConfig = {environmentData: {variableDurationAllowed: false}};
         await testClientReject(state, undefined, undefined,
             () => simidClient.requestPlay(),
             SIMIDErrors.unspecifiedClientError, 'requestPlay not allowed when variableDurationAllowed is false');
 
-        simidClient._playerConfig = { environmentData: {variableDurationAllowed: true} };
+        simidClient._playerConfig = {environmentData: {variableDurationAllowed: true}};
         await testClientRequest(state, 'SIMID:Creative:requestPlay', undefined,
             () => simidClient.requestPlay(), undefined);
         await testClientReject(state, 'SIMID:Creative:requestPlay', undefined,
@@ -428,7 +426,7 @@ describe('test simid client', () => {
 
     test('test requestSkip', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         await testClientRequest(state, 'SIMID:Creative:requestSkip', undefined,
             () => simidClient.requestSkip(), undefined);
@@ -439,7 +437,7 @@ describe('test simid client', () => {
 
     test('test requestStop', async () => {
         const state = newStartedTestState();
-        const { simidClient } = state;
+        const {simidClient} = state;
 
         simidClient.debug = true; // also see how things log
 
@@ -451,7 +449,7 @@ describe('test simid client', () => {
     });
 
     test('test media events', () => {
-        const { player, simidClient, playerWindow } = newStartedTestState();;
+        const {player, simidClient, playerWindow} = newStartedTestState();
 
         function testEvent(event, args) {
             simidClient.onMediaEvent = jest.fn();
@@ -486,8 +484,8 @@ describe('test simid client', () => {
     });
 });
 
-async function testPlayerRequest(state, type, args, waitForResponse) {
-    const { player, playerWindow, simidClient } = state;
+function testPlayerRequest(state, type, args, waitForResponse) {
+    const {player, playerWindow, simidClient} = state;
 
     const eventListener = jest.fn();
     const eventType = simidClient._getEventType(type);
@@ -497,34 +495,43 @@ async function testPlayerRequest(state, type, args, waitForResponse) {
 
     const requestMsg = player.sendPlayerMessage(type, args);
 
-    if (waitForResponse) await waitForResponse();
+    if (waitForResponse) {
+        return waitForResponse().then(verifyResponse);
+    } else {
+        verifyResponse();
+        return;
+    }
 
-    expect(playerWindow.lastMessage).toEqual(expect.objectContaining({type: 'resolve', args: {messageId: requestMsg.messageId, value: undefined}}));
+    function verifyResponse() {
+        const lastMsg = playerWindow.lastMessage;
+        expect(lastMsg).toMatchObject({type: 'resolve', args: {messageId: requestMsg.messageId}});
+        expect(lastMsg.args.value).toBeUndefined();
 
-    if (eventListener) {
-        const eventData = args || {};
-        const expectedEvent = {...eventData, type: eventType};
-        expect(eventListener).toHaveBeenCalledWith(expectedEvent);
+        if (eventListener) {
+            const eventData = args || {};
+            const expectedEvent = {...eventData, type: eventType};
+            expect(eventListener).toHaveBeenCalledWith(expectedEvent);
 
-        // Verify event cleanup
-        if (simidClient.isStopped) {
-            expect(simidClient._eventListeners).toEqual({});
-        } else {
-            expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBeGreaterThanOrEqual(0);
-            simidClient.removeEventListener(eventType, eventListener);
-            expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBe(-1);
+            // Verify event cleanup
+            if (simidClient.isStopped) {
+                expect(simidClient._eventListeners).toEqual({});
+            } else {
+                expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBeGreaterThanOrEqual(0);
+                simidClient.removeEventListener(eventType, eventListener);
+                expect(simidClient._eventListeners[eventType].indexOf(eventListener)).toBe(-1);
+            }
         }
     }
 }
 
 function testPlayerReject(state, type, args, errorCode, errMessage) {
-    const { player, playerWindow } = state;
+    const {player, playerWindow} = state;
     const requestMsg = player.sendPlayerMessage(type, args);
-    expect(playerWindow.lastMessage).toEqual(expect.objectContaining({type: 'reject', args: {messageId: requestMsg.messageId, value: { errorCode, message: errMessage }}}));
+    expect(playerWindow.lastMessage).toMatchObject({ type: 'reject', args: {messageId: requestMsg.messageId, value: {errorCode, message: errMessage}}});
 }
 
 async function testClientRequest(state, type, expectedArgs, requestAction, requestResult) {
-    const { player, simidClient, playerWindow, adWindow } = state;
+    const {player, simidClient, playerWindow, adWindow} = state;
     playerWindow.lastMessage = null;
     adWindow.lastMessage = null;
 
@@ -542,11 +549,11 @@ async function testClientRequest(state, type, expectedArgs, requestAction, reque
     const resolveMsg = adWindow.lastMessage;
     expect(resolveMsg).toBeDefined();
     expect(resolveMsg.type).toEqual('resolve');
-    expect(resolveMsg.args).toEqual({ messageId: clientMsg.messageId, value: requestResult });
+    expect(resolveMsg.args).toEqual({messageId: clientMsg.messageId, value: requestResult});
 }
 
 async function testClientReject(state, type, expectedArgs, requestAction, errorCode, errMessage) {
-    const { player, simidClient, playerWindow, adWindow } = state;
+    const {player, simidClient, playerWindow, adWindow} = state;
     playerWindow.lastMessage = null;
     adWindow.lastMessage = null;
 
@@ -563,7 +570,7 @@ async function testClientReject(state, type, expectedArgs, requestAction, errorC
         player.rejectClientRequest(clientMsg, errorCode, errMessage);
     }
 
-    await expect(requestPromise).rejects.toThrowError({ errorCode, message: errMessage, clientRequest: clientMsg });
+    await expect(requestPromise).rejects.toThrowError({errorCode, message: errMessage, clientRequest: clientMsg});
 
     if (type) {
         const resolveMsg = adWindow.lastMessage;
@@ -581,7 +588,7 @@ class WindowStub {
     lastMessage;
 
     constructor(id) {
-       this.id = id;
+        this.id = id;
     }
 
     postMessage(msgJson, domain) {
@@ -640,11 +647,11 @@ class PlayerStub {
     }
 
     resolveClientRequest(clientMsg, value) {
-        this.sendPlayerMessage('resolve', {messageId: clientMsg.messageId, value });
+        this.sendPlayerMessage('resolve', {messageId: clientMsg.messageId, value});
     }
 
     rejectClientRequest(clientMsg, errorCode, errMessage) {
-        this.sendPlayerMessage('reject', {messageId: clientMsg.messageId, value: { errorCode, message: errMessage } });
+        this.sendPlayerMessage('reject', {messageId: clientMsg.messageId, value: {errorCode, message: errMessage}});
     }
 }
 

--- a/src/simid/__tests__/simid-client-tests.js
+++ b/src/simid/__tests__/simid-client-tests.js
@@ -110,9 +110,7 @@ describe('test simid client', () => {
             });
             return responsePromise;
         };
-        await testPlayerRequest(state, 'SIMID:Player:adSkipped', undefined, () => {
-            return responsePromise;
-        });
+        await testPlayerRequest(state, 'SIMID:Player:adSkipped', undefined, () => responsePromise);
         expect(simidClient.isStopped).toBe(true);
         expect(resolved).toBe(true);
     });
@@ -145,9 +143,7 @@ describe('test simid client', () => {
             });
             return responsePromise;
         };
-        await testPlayerRequest(state, 'SIMID:Player:adStopped', undefined, () => {
-            return responsePromise;
-        });
+        await testPlayerRequest(state, 'SIMID:Player:adStopped', undefined, () => responsePromise);
         expect(simidClient.isStopped).toBe(true);
         expect(resolved).toBe(true);
     });

--- a/src/simid/simid-client.js
+++ b/src/simid/simid-client.js
@@ -12,6 +12,7 @@ import { v4 as uuid } from 'uuid';
  */
 export class SIMIDClient {
     isActive;
+    isStopped;
     debug;
 
     /**
@@ -29,6 +30,7 @@ export class SIMIDClient {
         this._nextMessageId = 0;
         this._sessionId = undefined;
         this.isActive = false;
+        this.isStopped = false;
         this.debug = false;
         this._onPlayerMessage = this._onPlayerMessage.bind(this);
 
@@ -47,8 +49,8 @@ export class SIMIDClient {
     }
 
     stop() {
-        if (!this.isActive) return;
-        this.isActive = false;
+        if (this.isStopped) return;
+        this.isStopped = true;
         this._contentWindow.removeEventListener('message', this._onPlayerMessage);
         this._pendingClientRequests = {};
         this._eventListeners = {};
@@ -286,7 +288,9 @@ export class SIMIDClient {
      * @private
      */
     _sendClientMessage(type, args) {
-        if (!this.isActive) return;
+        if (!this.isActive) return; // no traffic allowed if not active
+        if (this.isStopped && !(type == 'reject' || type == 'resolve')) return; // only responses allowed if stopped
+
         const message = this._createMessage(type, args);
         this._postClientMessage('client message', message);
     }
@@ -299,7 +303,7 @@ export class SIMIDClient {
      * @private
      */
     _sendClientRequest(type, args) {
-        if (!this.isActive) return;
+        if (!this.isActive || this.isStopped) return; // no traffic allowed if not active
 
         const message = this._createMessage(type, args);
 
@@ -387,7 +391,7 @@ export class SIMIDClient {
         }
     }
 
-    _playerResponse(requestId, requestType, clientAction, postResponseAction) {
+    _playerResponse(requestId, requestType, clientAction) {
         let response;
         try {
             response = clientAction();
@@ -395,7 +399,6 @@ export class SIMIDClient {
                 return response
                     .then(result => {
                         this._resolvePlayerRequest(requestId, result);
-                        if (postResponseAction) postResponseAction();
                         return result;
                     })
                     .catch(err => {
@@ -403,7 +406,6 @@ export class SIMIDClient {
                     });
             } else {
                 this._resolvePlayerRequest(requestId, response);
-                if (postResponseAction) postResponseAction();
             }
         } catch (error) {
             this._rejectPlayerRequest(requestId, requestType, SIMIDErrors.adInternalError, error);
@@ -455,19 +457,21 @@ export class SIMIDClient {
     }
 
     _adSkipped(requestId, requestType) {
-        // Stop only after the final message is sent.
         this._playerResponse(requestId, requestType, () => {
-            this.onAdSkipped();
+            const possiblePromise = this.onAdSkipped();
             this._invokeEventListeners(requestType);
-        }, () => this.stop());
+            this.stop();
+            return possiblePromise;
+        });
     }
 
     _adStopped(requestId, requestType) {
-        // Stop only after the final message is sent.
         this._playerResponse(requestId, requestType, () => {
-            this.onAdStopped();
+            const possiblePromise = this.onAdStopped();
             this._invokeEventListeners(requestType);
-        }, () => this.stop());
+            this.stop();
+            return possiblePromise;
+        });
     }
 
     _adBackgrounded(requestId, requestType) {
@@ -535,9 +539,15 @@ export class SIMIDClient {
     onMediaEvent(event, args) {
     }
 
+    /**
+     * @return {Promise|undefined} Returns a promise if a wait is needed before responding to the player.
+     */
     onAdSkipped() {
     }
 
+    /**
+     * @return {Promise|undefined} Returns a promise if a wait is needed before responding to the player.
+     */
     onAdStopped() {
     }
 


### PR DESCRIPTION
Jira: [PI-2895](https://infillion.atlassian.net/browse/PI-2895): Create a new end point for SIMID support to be loaded into ad's iframe as creative file

Support delays before actually ad stopping, e.g. to support C3 final state transition processing.

[PI-2895]: https://infillion.atlassian.net/browse/PI-2895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ