### PR TITLE
PI-3311 - truex_servers: added `qrCodeServerUrl`

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -31,4 +31,11 @@ jobs:
         run: yarn install
 
       - name: Run Unit Tests
-        run: yarn run test
+        run: yarn run test:ci
+
+      - name: Test Report
+        uses: dorny/test-reporter@v2
+        with:
+          name: Jest Unit Tests
+          path: test-results/junit.xml
+          reporter: jest-junit

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@ yarn-error.log
 **/dist/
 /concat/
 /coverage/
+/test-results/
 
 .vscode
 
 # IntelliJ project files
 /.idea/
+/*.iml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog
 
+## v1.11.6
+* [PI-3311](https://infillion.atlassian.net/browse/PI-3311): truex_servers, added `qrCodeServerUrl`
+* [PI-2952](https://infillion.atlassian.net/browse/PI-2952): migrate travis deploy script to Github Actions
+
+## v1.11.5
+* [PI-2895](https://infillion.atlassian.net/browse/PI-2895): Create a new end point for SIMID support to be loaded into ad's iframe as creative file
+
 ## v1.11.4
 * [PI-2895](https://infillion.atlassian.net/browse/PI-2895): Create a new end point for SIMID support to be loaded into ad's iframe as creative file
 * [PI-2897](https://infillion.atlassian.net/browse/PI-2897): Create SIMID Core Message component
-* [PI-2952](https://infillion.atlassian.net/browse/PI-2952): truex-shared-js - migrate travis deploy script to Github Actions
 
 ## v1.10.3
 * [PI-2658](https://infillion.atlassian.net/browse/PI-2658): Crunchyroll Desktop placement not including a network user id

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truex-shared",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Common JS code shared across true[X] repos",
   "private": true,
   "files": [
@@ -9,6 +9,7 @@
   "main": "./src/",
   "scripts": {
     "test": "jest",
+    "test:ci": "jest --ci --reporters=default --reporters=jest-junit",
     "watch": "jest --watch",
     "coverage": "jest --coverage"
   },
@@ -16,9 +17,11 @@
     "@babel/core": "^7.8.3",
     "@babel/preset-env": "^7.4.1",
     "@babel/runtime": "^7.4.1",
+    "@types/jest": "^29.5.14",
     "babel-jest": "^25.1.0",
-    "core-js": "3",
+    "core-js": "3.20.3",
     "jest": "^29.7.0",
+    "jest-junit": "^16.0.0",
     "jest-environment-jsdom": "^29.7.0",
     "whatwg-fetch": "^3.0.0"
   },
@@ -33,5 +36,14 @@
     "transform": [
       "babelify"
     ]
+  },
+  "jest-junit": {
+    "outputDirectory": "test-results",
+    "outputName": "junit.xml",
+    "ancestorSeparator": " › ",
+    "uniqueOutputName": "false",
+    "suiteNameTemplate": "{filepath}",
+    "classNameTemplate": "{classname}",
+    "titleTemplate": "{title}"
   }
 }

--- a/src/utils/__tests__/truex_servers-test.js
+++ b/src/utils/__tests__/truex_servers-test.js
@@ -13,6 +13,7 @@ describe("truex_servers testing", () => {
         expect(isTruexProductionUrl("https://qa-media.truex.com")).toBe(false);
         expect(isTruexProductionUrl("https://qa-server.truex.com")).toBe(false);
         expect(isTruexProductionUrl("https://media.somewhere.else.com")).toBe(false);
+        expect(isTruexProductionUrl("https://qa-rtb-tf.truex.com")).toBe(false);
 
         expect(isTruexProductionUrl("qa-media.truex.com")).toBe(false);
         expect(isTruexProductionUrl("media.truex.com")).toBe(true);
@@ -65,11 +66,13 @@ describe("truex_servers testing", () => {
                 expect(servers.measureServerUrl).toBe("https://measure.truex.com");
                 expect(servers.engageServerUrl).toBe("https://engage.truex.com");
                 expect(servers.serverUrlOf("something.truex.com")).toBe("https://something.truex.com");
+                expect(servers.qrCodeServerUrl).toBe("https://qr.truex.com");
             } else {
                 expect(servers.truexServerUrl).toBe("https://qa-serve.truex.com");
                 expect(servers.mediaServerUrl).toBe("https://qa-media.truex.com");
                 expect(servers.measureServerUrl).toBe("https://qa-measure.truex.com");
                 expect(servers.engageServerUrl).toBe("https://qa-engage.truex.com");
+                expect(servers.qrCodeServerUrl).toBe("https://qa-qr.truex.com");
                 expect(servers.serverUrlOf("something.truex.com")).toBe("https://qa-something.truex.com");
             }
         }

--- a/src/utils/truex_servers.js
+++ b/src/utils/truex_servers.js
@@ -1,10 +1,9 @@
 
 export function isTruexProductionUrl(url) {
     if (url) {
-        const m = url.match(/^(https?:\/\/)?([a-z])+.truex.com/);
+        const m = url.match(/^(https?:\/\/)?([a-zA-Z0-9\-_]+).truex.com/);
         if (m) {
-            if (m[2].startsWith('qa-')) return false;
-            return true;
+            return !m[2].startsWith('qa-');
         }
     }
     return false;
@@ -34,6 +33,7 @@ export class TruexServers {
         this.engageServerUrl = serverUrlOf('engage.truex.com');
         this.mediaServerUrl = serverUrlOf('media.truex.com');
         this.measureServerUrl = serverUrlOf('measure.truex.com');
+        this.qrCodeServerUrl = serverUrlOf('qr.truex.com');
 
         /**
          * @deprecated use engage.truex.com instead. serve.truex.com is now just a redirect to it.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,6 +1464,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^29.5.14":
+  version "29.5.14"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.14.tgz#2b910912fa1d6856cadcd0c1f95af7df1d6049e5"
+  integrity sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
 "@types/jsdom@^20.0.0":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-20.0.1.tgz#07c14bc19bd2f918c1929541cdaacae894744808"
@@ -2093,7 +2101,7 @@ core-js-compat@^3.20.0, core-js-compat@^3.20.2:
     browserslist "^4.19.1"
     semver "7.0.0"
 
-core-js@3:
+core-js@3.20.3:
   version "3.20.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.20.3.tgz#c710d0a676e684522f3db4ee84e5e18a9d11d69a"
   integrity sha512-vVl8j8ph6tRS3B8qir40H7yw7voy17xL0piAjlbBUsH7WIfzoedL/ZOr1OV9FyZQLWXsayOJyV4tnRyXR85/ag==
@@ -2402,7 +2410,7 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expect@^29.7.0:
+expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
   integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
@@ -3148,6 +3156,16 @@ jest-haste-map@^29.7.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-junit@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-16.0.0.tgz#d838e8c561cf9fdd7eb54f63020777eee4136785"
+  integrity sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==
+  dependencies:
+    mkdirp "^1.0.4"
+    strip-ansi "^6.0.1"
+    uuid "^8.3.2"
+    xml "^1.0.1"
+
 jest-leak-detector@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz#5b7ec0dadfdfec0ca383dc9aa016d36b5ea4c728"
@@ -3631,6 +3649,11 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3888,7 +3911,7 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
-pretty-format@^29.7.0:
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
@@ -4558,6 +4581,11 @@ uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-to-istanbul@^9.0.1:
   version "9.3.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
@@ -4699,6 +4727,11 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
### JIRA
https://infillion.atlassian.net/browse/PI-3311

### Description
- added `truex_servers.qrCodeServerUrl`
- updated `unit-test.yml` workflow to publish test results

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [ ] Includes functional test coverage _(at feature-level, if applicable)_
- [ ] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)

