### PR TITLE
PI-3307: recognize the Kepler platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.11.7
+* [PI-3307](https://infillion.atlassian.net/browse/PI-3307): TAR Kepler: main video "flashes thru" videos playing in webview
+  * add Kepler as a recognized platform 
+
 ## v1.11.6
 * [PI-3311](https://infillion.atlassian.net/browse/PI-3311): truex_servers, added `qrCodeServerUrl`
 * [PI-2952](https://infillion.atlassian.net/browse/PI-2952): migrate travis deploy script to Github Actions

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "babel-jest": "^25.1.0",
     "core-js": "3.20.3",
     "jest": "^29.7.0",
-    "jest-junit": "^16.0.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-junit": "^16.0.0",
     "whatwg-fetch": "^3.0.0"
   },
   "dependencies": {

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -15,6 +15,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("Unknown");
             expect(platform.isCTV).toBe(false);
             expect(platform.isConsole).toBe(false);
@@ -80,6 +82,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("FireTV");
             expect(platform.model).toBe("Fire TV Stick (Gen 2)");
             expect(platform.modelId).toBe("AFTT");
@@ -130,6 +134,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("AndroidTV");
             expect(platform.model).toBe(platform.name);
             expect(platform.version).toBe("5.1");
@@ -177,6 +183,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("Android");
             expect(platform.model).toBe(platform.name);
             expect(platform.version).toBe("4.2");
@@ -205,6 +213,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("Android");
             expect(platform.model).toBe(platform.name);
             expect(platform.version).toBe("7.1.1");
@@ -229,6 +239,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("Vizio");
             expect(platform.isCTV).toBe(true);
             expect(platform.isConsole).toBe(false);
@@ -275,6 +287,7 @@ describe("TXMPlatform", () => {
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
             expect(platform.isComcast).toBe(true);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("Comcast");
             expect(platform.isCTV).toBe(true);
             expect(platform.isConsole).toBe(false);
@@ -360,6 +373,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("LG");
             expect(platform.model).toBe("LG Fake Model");
             expect(platform.version).toBe("1.2.3");
@@ -397,6 +412,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(true);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("Tizen");
             expect(platform.model).toBe("2018");
             expect(platform.version).toBe("4.0");
@@ -432,6 +449,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(true);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("PS4");
             expect(platform.model).toBe("PS4");
             expect(platform.version).toBe("5.05");
@@ -452,6 +471,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(true);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("PS4");
             expect(platform.model).toBe("PS4");
             expect(platform.version).toBe("WebMAF/v1.2.30.4");
@@ -489,6 +510,8 @@ describe("TXMPlatform", () => {
             expect(platform.isPS4).toBe(false);
             expect(platform.isPS5).toBe(true);
             expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("PS5");
             expect(platform.model).toBe("PS5");
             expect(platform.version).toBe("1.05");
@@ -525,6 +548,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(true);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("XboxOne");
             expect(platform.model).toBe("Windows.Xbox");
             expect(platform.version).toBe("Unknown");
@@ -560,6 +585,8 @@ describe("TXMPlatform", () => {
             expect(platform.isTizen).toBe(false);
             expect(platform.isPS4).toBe(false);
             expect(platform.isXboxOne).toBe(true);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(false);
             expect(platform.name).toBe("XboxOne");
             expect(platform.model).toBe("Windows.Xbox");
             expect(platform.version).toBe("1.2.3");

--- a/src/focus_manager/__tests__/txm_platform-test.js
+++ b/src/focus_manager/__tests__/txm_platform-test.js
@@ -295,6 +295,45 @@ describe("TXMPlatform", () => {
         });
     });
 
+    describe("Kepler Tests", () => {
+
+        let platform = new TXMPlatform(
+            "Mozilla/5.0 (Linux; Kepler 1.1; AFTCA002 user-external/4418; wv) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Chrome/132.0.6834.209 Safari/537.36"
+        );
+
+        test("recognize the Kepler platform", () => {
+            expect(platform.isUnknown).toBe(false);
+            expect(platform.isFireTV).toBe(false);
+            expect(platform.isAndroidTV).toBe(false);
+            expect(platform.isVizio).toBe(false);
+            expect(platform.isLG).toBe(false);
+            expect(platform.isTizen).toBe(false);
+            expect(platform.isPS4).toBe(false);
+            expect(platform.isXboxOne).toBe(false);
+            expect(platform.isComcast).toBe(false);
+            expect(platform.isKepler).toBe(true);
+            expect(platform.name).toBe("Kepler");
+            expect(platform.version).toBe("1.1");
+            expect(platform.isCTV).toBe(true);
+            expect(platform.isConsole).toBe(false);
+            expect(platform.model).toBe("AFTCA002");
+        });
+
+        test("Kepler key mapping", () => {
+            const keyCodes = platform.keyCodes;
+            expect(platform.getInputAction(keyCodes.upArrow)).toBe(inputActions.moveUp);
+            expect(platform.getInputAction(keyCodes.downArrow)).toBe(inputActions.moveDown);
+            expect(platform.getInputAction(keyCodes.leftArrow)).toBe(inputActions.moveLeft);
+            expect(platform.getInputAction(keyCodes.rightArrow)).toBe(inputActions.moveRight);
+            expect(platform.getInputAction(keyCodes.enter)).toBe(inputActions.select);
+            expect(platform.getInputAction(keyCodes.backspace)).toBe(inputActions.back);
+            expect(platform.getInputAction(keyCodes.esc)).toBe(inputActions.back);
+            expect(platform.getInputAction(179)).toBe(inputActions.playPause);
+            expect(platform.getInputAction(227)).toBe(inputActions.rewind);
+            expect(platform.getInputAction(228)).toBe(inputActions.fastForward);
+        });
+    });
+
     describe("LG Tests", () => {
         // Mock LG OS API
         window.PalmSystem = new Object();

--- a/src/focus_manager/txm_platform.js
+++ b/src/focus_manager/txm_platform.js
@@ -73,6 +73,7 @@ export class TXMPlatform {
         this.isAndroidMobile = false;
         this.isAndroidTV = false;
         this.isFireTV = false;
+        this.isKepler = false;
 
         this.isXboxOne = false;
         this.isNintendoSwitch = false;
@@ -122,7 +123,7 @@ export class TXMPlatform {
     get isHandheld() { return this.isIPhone || this.isAndroidMobile && /Mobile/.test(this.userAgent) }
     get isTablet() { return this.isIPad || this.isAndroidMobile && !this.isHandheld }
 
-    get isCTV() { return this.isLG || this.isVizio || this.isTizen || this.isAndroidTV || this.isFireTV || this.isComcast }
+    get isCTV() { return this.isLG || this.isVizio || this.isTizen || this.isAndroidTV || this.isFireTV || this.isComcast || this.isKepler }
     get isConsole() { return this.isXboxOne || this.isPS4 || this.isPS5 || this.isNintendoSwitch }
 
 
@@ -268,6 +269,9 @@ export class TXMPlatform {
             } else {
                 configureForAndroid();
             }
+
+        } else if (/Kepler/.test(userAgent)) {
+            configureForKepler();
 
         } else if (/Linux/.test(userAgent) && (window.$badger || !window.localStorage)) {
             // "Real" comcast apps uses the badger lib.
@@ -640,6 +644,21 @@ export class TXMPlatform {
             actionKeyCodes[inputActions.fastForward] = 228;
             actionKeyCodes[inputActions.rewind] = 227;
             actionKeyCodes[inputActions.extra] = 82;
+        }
+
+        function configureForKepler() {
+            self.isKepler = true;
+            self.name = "Kepler";
+
+            // E.g. Mozilla/5.0 (Linux; Kepler 1.1; AFTCA002 user-external/4418; wv) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Chrome/132.0.6834.209 Safari/537.36
+            const matches = userAgent.match(/Kepler ([0-9.]+); (\S+)/);
+            self.version = matches && matches[1] || "?.?";
+            self.model = matches && matches[2] || "Unknown";
+
+            addDefaultKeyMap();
+            actionKeyCodes[inputActions.playPause] = 179;
+            actionKeyCodes[inputActions.rewind] = 227;
+            actionKeyCodes[inputActions.fastForward] = 228;
         }
 
         function configureForUnknownPlatform() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1937,9 +1937,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001646:
-  version "1.0.30001649"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz"
-  integrity sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==
+  version "1.0.30001743"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz"
+  integrity sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Jira: [PI-3307](https://infillion.atlassian.net/browse/PI-3307): TAR Kepler: main video "flashes thru" videos playing in webview

* add Kepler as a recognized platform

TODO: use in truex-bluescript and C3 to recognize Kepler for video flash work arounds

[PI-3307]: https://infillion.atlassian.net/browse/PI-3307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ